### PR TITLE
Changed the default URL scheme in sphinx-sitemap to exclude language.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,6 +91,7 @@ html_title = "BrainGlobe"
 # Sphinx will create the appropriate CNAME file in the build directory
 # https://www.sphinx-doc.org/en/master/usage/extensions/githubpages.html
 html_baseurl = "https://brainglobe.info/"
+sitemap_url_scheme = "{link}"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/neuroinformatics-unit/.github/blob/main/CONTRIBUTING.md).

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Sphinx-sitemap introduced a /en/ path to all urls causing them to be invalid.

**What does this PR do?**
Sets the sitemap-url-scheme to only generate the link, without appending language or version.

## References

## How has this PR been tested?
The site builds locally, sitemap checked by eye and links were followed to ensure they're working.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
