### PR TITLE
Add social networks

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -126,6 +126,16 @@ html_theme_options = {
             "icon": "fa-brands fa-twitter",
         },
         {
+            "name": "Mastodon",
+            "url": "https://mastodon.online/@brainglobe",
+            "icon": "fa-brands fa-mastodon",
+        },
+        {
+            "name": "Bluesky",
+            "url": "https://bsky.app/profile/brainglobe.bsky.social",
+            "icon": "fa-solid fa-square",
+        },
+        {
             # Label for this link
             "name": "Zulip (Developer chat)",
             # URL where the link will redirect


### PR DESCRIPTION
Twitter/X used to be fairly useful to spread the word about new tools. This no longer seems to be the case, so I've hedged my bets and set up mastodon & bluesky accounts for BrainGlobe.

Current plan is to cross post to all of them and see if any of them turn out to be useful.

First step is people finding out about them, so I've added links to the website here. 