### PR TITLE
remove unsupported notice for `brainrender`

### DIFF
--- a/docs/source/documentation/brainrender/index.md
+++ b/docs/source/documentation/brainrender/index.md
@@ -1,12 +1,5 @@
 # brainrender
 
-**Update 2023-10-05:  brainrender is currently unsupported**
-
-**brainrender has a number of critical bugs that we are aiming to address. Until these issues are fixed, we will be able to offer very limited support.**
-
-**For further details please see [this issue](https://github.com/brainglobe/brainrender/issues/247).**
-
-
 ## Introduction
 
 ![Allen mouse brain renderings](images/aba.webp)


### PR DESCRIPTION
:warning: depends on https://github.com/brainglobe/brainrender/pull/250 being merged first.

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
We can support brainrender again (once https://github.com/brainglobe/brainrender/pull/250 is merged) :tada: 

**What does this PR do?**
Removes the unsupported notice for `brainrender`.

## References



## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://docs.cellfinder.info/for-developers/documentation) for details.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
