### PR TITLE
remove references to manual segmentation in brainglobe-segmentation

### DIFF
--- a/docs/source/blog/version1/brainreg_update_live.md
+++ b/docs/source/blog/version1/brainreg_update_live.md
@@ -14,7 +14,7 @@ Previously, there were three tools with the prefix `brainreg` ("brain registrati
 
 - `brainreg` was the core Python package that contained the functional code for performing registration of an atlas to a sample image (sequence).
 - `brainreg-napari` provided a plugin to perform the registration steps interactively through napari. It depended on `brainreg` for the core functionality.
-- `brainreg-segment` was a companion to `brainreg` that allowed for manual segmentation of regions/objects within the brain. However it was not necessarily involved with the registration process itself.
+- `brainreg-segment` was a companion to `brainreg` that allowed for segmentation of regions/objects within the brain. However it was not necessarily involved with the registration process itself.
 
 This release sees `brainreg` come bundled with its napari plugin as an optional package extra, rather than requiring users to install the two packages separately.
 Consequentially, `brainreg-napari` has been retired; we recommend you uninstall this package from your environments when you update.

--- a/docs/source/documentation/brainglobe-segmentation/index.md
+++ b/docs/source/documentation/brainglobe-segmentation/index.md
@@ -1,7 +1,7 @@
 # brainglobe-segmentation
 
 
-brainglobe-segmentation is a companion to [brainreg](../brainreg/index) allowing manual segmentation of regions/objects 
+brainglobe-segmentation is a companion to [brainreg](../brainreg/index) allowing segmentation of regions/objects 
 within the brain (e.g. injection sites, probes etc.) allowing for automated analysis of brain region distribution, 
 and visualisation (e.g. in [brainrender](../brainrender/index)).
 

--- a/docs/source/documentation/cellfinder/troubleshooting/error-messages.md
+++ b/docs/source/documentation/cellfinder/troubleshooting/error-messages.md
@@ -25,7 +25,7 @@ Otherwise cellfinder will interpret the path as two inputs, separated by a space
 ### CommandLineInputError: File path: cannot be found.
 
 ```bash
-imlib.general.exceptions.CommandLineInputError: File path: '/media/adam/Storage/cellfinder.md/data/dataset1' cannot be found.
+imlib.general.exceptions.CommandLineInputError: File path: '/media/adam/Storage/cellfinder/data/dataset1' cannot be found.
 ```
 
 If you see an error like this, there could be a few possible reasons, e.g.:

--- a/screenshot_maker.py
+++ b/screenshot_maker.py
@@ -53,8 +53,8 @@ def clean_configure_segmentation_widget(tmp_path, standard_size_viewer, take_vie
 
         tmp_input_dir = tmp_path / "brainreg_output"
         shutil.copytree(brainreg_dir, tmp_input_dir)
-        shutil.rmtree(brainreg_dir/"manual_segmentation"/"atlas_space", ignore_errors=True)
-        shutil.rmtree(brainreg_dir/"manual_segmentation"/"sample_space", ignore_errors=True)
+        shutil.rmtree(brainreg_dir/"segmentation"/"atlas_space", ignore_errors=True)
+        shutil.rmtree(brainreg_dir/"segmentation"/"sample_space", ignore_errors=True)
 
         segmentation_widget.atlas_space = True
         segmentation_widget.plugin = (
@@ -62,7 +62,7 @@ def clean_configure_segmentation_widget(tmp_path, standard_size_viewer, take_vie
         )
         segmentation_widget.directory = Path(tmp_input_dir)
         segmentation_widget.load_brainreg_directory()
-        # delete manual segmentation data to ensure it's saved correctly in tests
+        # delete segmentation data to ensure it's saved correctly in tests
         shutil.rmtree(segmentation_widget.paths.main_directory)
         viewer.layers['Registered image'].contrast_limits=(0, 600)
         


### PR DESCRIPTION
Updates website to reflect that `brainglobe-segmentation` isn't only for manual segmentation.

Requires https://github.com/brainglobe/brainglobe-segmentation/pull/150

Also fixes a stray mistake that entered the cellfinder troubleshooting section