### PR TITLE
Update website banner now that restructuring _has happened_

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ extensions = [
     "numpydoc",
     "nbsphinx",
     "notfound.extension",
-    "sphinx_copybutton"
+    "sphinx_copybutton",
 ]
 
 # Configure the myst parser to enable cool markdown features
@@ -108,7 +108,7 @@ html_favicon = "_static/brainglobe.png"
 
 ## Cutomize the theme
 html_theme_options = {
-    "announcement": "BrainGlobe is undergoing restructuring. Keep track of the latest developments on <a href='https://brainglobe.info/blog/version1/version_1_announcement.html'>the blog</a>",
+    "announcement": "BrainGlobe version 1 is here! Head over to  <a href='https://brainglobe.info/blog/version1/version_1_released.html'>the blog</a> to find out more",
     "icon_links": [
         {
             # Label for this link


### PR DESCRIPTION
Changes the website banner from "we are doing some restructuring" to "things have been restructured, head here to find out what's happened".

We could also just remove the header, but I figured we should give a warning about the completed version 1 release for at least a while.