### PR TITLE
Add bg-atlasapi citation info

### DIFF
--- a/docs/source/documentation/bg-atlasapi/index.md
+++ b/docs/source/documentation/bg-atlasapi/index.md
@@ -55,3 +55,10 @@ usage/using-the-files-directly
 :maxdepth: 1
 adding-a-new-atlas
 ```
+
+## Citation
+If you find the BrainGlobe Atlas API useful, please cite the paper in your work:
+
+>Claudi, F., Petrucco, L., Tyson, A. L., Branco, T., Margrie, T. W. and Portugues, R. (2020). BrainGlobe Atlas API: a common interface for neuroanatomical atlases. Journal of Open Source Software, 5(54), 2668, https://doi.org/10.21105/joss.02668
+
+**Don't forget to cite the developers of the atlas that you used!**

--- a/docs/source/documentation/brainreg/index.md
+++ b/docs/source/documentation/brainreg/index.md
@@ -54,5 +54,4 @@ Lastly, if you can, please cite the BrainGlobe Atlas API that provided the atlas
 
 >Claudi, F., Petrucco, L., Tyson, A. L., Branco, T., Margrie, T. W. and Portugues, R. (2020). BrainGlobe Atlas API: a common interface for neuroanatomical atlases. Journal of Open Source Software, 5(54), 2668, https://doi.org/10.21105/joss.02668
 
-**Don't forget to cite the developers of the atlas that you used (e.g. the Allen Brain Atlas)!**
-
+**Don't forget to cite the developers of the atlas that you used!**


### PR DESCRIPTION
Closes https://github.com/brainglobe/bg-atlasapi/issues/182 and linked to https://github.com/brainglobe/bg-atlasapi/pull/189