### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/docs/source/community/developers/repositories/brainglobe-meta/index.md
+++ b/docs/source/community/developers/repositories/brainglobe-meta/index.md
@@ -40,7 +40,7 @@ The resulting `brainglobe` version 1.0.0 release prevents users from installing 
 
 Minor or patch updates to `brainglobe` we envision to be cases where multiple tools have undergone performance improvements, minor patches, or under-the-hood code refactoring that we feel benefits the user experience, but does not require a change in how the user interacts with these tools.
 A typical example of this might be when a function appears in both `brainglobe-tool-A` and `brainglobe-tool-B`, so we decide to refactor it into `brainglobe-utils` which is a common dependency.
-In this case; each of `brainglobe-tool-A`, `brainglobe-tool-B`, and `brainglobe-utils` would get new releases, and furthermore both `brainglobe-tool-A` and `brainglobe-tool-B` would now depend on the new version of `brainglobe-utils`.
+In this case, each of `brainglobe-tool-A`, `brainglobe-tool-B`, and `brainglobe-utils` would get new releases, and furthermore both `brainglobe-tool-A` and `brainglobe-tool-B` would now depend on the new version of `brainglobe-utils`.
 We would then decide to release a minor version of the meta-package, which updates the minimum version of these three packages - from the user perspective, this will come in a single update.
 
 ### Dependency Pinning

--- a/docs/source/community/developers/specific_repos.md
+++ b/docs/source/community/developers/specific_repos.md
@@ -1,6 +1,6 @@
 # Specific Repository Developer Documentation
 
-To complete BrainGlobe's [general developer guidelines](./index.md), some of our tools and repositories contain additional developer information which extends that the general guidelines.
+To complete BrainGlobe's [general developer guidelines](./index.md), some of our tools and repositories contain additional developer information which extends the general guidelines.
 Typically this information concerns the directory to store user caches, conventions for naming or storing data in the repository for testing purposes, and similar.
 You can check the repositories with additional developer information by following the links below.
 

--- a/docs/source/community/developers/tooling.md
+++ b/docs/source/community/developers/tooling.md
@@ -29,7 +29,7 @@ to edit the `.pre-commit-config.yaml` file by adding the additional dependency t
 ```
 
 ## Versioning
-We use [semantic versioning](https://semver.org/), which uses a `MAJOR`.`MINOR`.`PATCH` versiong number where these mean:
+We use [semantic versioning](https://semver.org/), which uses a `MAJOR`.`MINOR`.`PATCH` versioning number where these mean:
 
 * PATCH = small bugfix
 * MINOR = new feature

--- a/docs/source/community/developers/tooling.md
+++ b/docs/source/community/developers/tooling.md
@@ -29,6 +29,7 @@ to edit the `.pre-commit-config.yaml` file by adding the additional dependency t
 ```
 
 ## Versioning
+
 We use [semantic versioning](https://semver.org/), which uses a `MAJOR`.`MINOR`.`PATCH` versioning number where these mean:
 
 * PATCH = small bugfix

--- a/docs/source/documentation/bg-atlasapi/adding-a-new-atlas.md
+++ b/docs/source/documentation/bg-atlasapi/adding-a-new-atlas.md
@@ -4,7 +4,7 @@
 
 BrainGlobe atlases are downloaded locally to the user’s machine whenever they try to use an atlas that has not yet been 
 downloaded.
-By default, they will end up in the `.../username/.brainglobe` folder,
+By default, they will end up in the `~/.brainglobe` folder,
 unless differently specified in the `bg-atlasapi` configuration.
 
 The BrainGlobeAtlas class fetches those atlases from a dedicated GIN repository
@@ -161,7 +161,7 @@ load and visualize a set of .obj files for quick inspection, e.g.:
 ```python
 from bg_atlasgen.mesh_utils import inspect_meshes_folder
 
-inspect_meshes_folder("/home/username/.brainglobe/temp/allen_mouse_10um_v1.0/meshes")
+inspect_meshes_folder("~/.brainglobe/temp/allen_mouse_10um_v1.0/meshes")
 ```
 
 

--- a/docs/source/documentation/bg-atlasapi/usage/atlas-details.md
+++ b/docs/source/documentation/bg-atlasapi/usage/atlas-details.md
@@ -8,7 +8,7 @@ The BrainGlobe atlas API includes a number of atlases in a standardised form tha
 - Brain region annotations
 - Resolution
 
-Sometimes chooseing the most appropriate atlas for a specific question is easy (e.g., there is currently only one 
+Sometimes choosing the most appropriate atlas for a specific question is easy (e.g., there is currently only one 
 rat atlas in the API). However, in some cases (e.g. adult mouse brains) there are many options. In some cases 
 the annotations included with an atlas will dictate the choice — if the brain region you are studying is not included 
 in an atlas, it is not much use! In other cases the reference image will be important. If you have imaged your sample 

--- a/docs/source/documentation/bg-atlasapi/usage/python-api.md
+++ b/docs/source/documentation/bg-atlasapi/usage/python-api.md
@@ -4,7 +4,7 @@
 
 To instantiate a `BrainGlobeAtlas` object, we need to instantiate it with the atlas name. The first time we use it, a 
 version of this atlas files will be downloaded from the [remote GIN repository](http://gin.g-node.org/brainglobe/atlases) 
-and stored on your local machine (by default, in `~..brainglobe`):
+and stored on your local machine (by default, in `~/.brainglobe`):
 
 ```python
 from bg_atlasapi import BrainGlobeAtlas

--- a/docs/source/documentation/bg-atlasapi/usage/using-the-files-directly.md
+++ b/docs/source/documentation/bg-atlasapi/usage/using-the-files-directly.md
@@ -2,7 +2,7 @@
 
 Although the API should provide you with the tools you need to work with the atlas \(and if they don't, please [raise an issue](https://github.com/brainglobe/bg-atlasapi/issues)\), you may wish to find the files themselves.
 
-By default, atlases will be downloaded and saved into your home directory in a hidden directory \(`.brainglobe`\), with one directory per atlas e.g. `/home/username/.brainglobe/allen_mouse_10um_v0.3`\).
+By default, atlases will be downloaded and saved into your home directory in a hidden directory \(`.brainglobe`\), with one directory per atlas e.g. `~/.brainglobe/allen_mouse_10um_v0.3`\).
 
 In each atlas directory, there will be the following subdirectories and files:
 


### PR DESCRIPTION
This PR fixes minor typos throughout the documentation, and makes sure "~/.brainglobe" is consistently used to match the [introduction to the BrainGlobe codebase for developers](https://brainglobe.info/community/developers/intro_to_codebase.html#user-data)
