### PR TITLE
Add a description of the hemispheres.tiff file

### DIFF
--- a/docs/source/documentation/brainglobe-atlasapi/usage/using-the-files-directly.md
+++ b/docs/source/documentation/brainglobe-atlasapi/usage/using-the-files-directly.md
@@ -8,6 +8,7 @@ In each atlas directory, there will be the following subdirectories and files:
 
 * `reference.tiff` The "template" brain image, i.e., a structural image of the brain \(or average of brains\) in which the annotations are defined
 * `annotation.tiff` An image of the same shape as `reference.tiff` but in which each pixel value corresponds to a unique brain area. A pixel value of 0 typically refers to areas outside the brain
+* `hemispheres.tiff` (optional) An image of the same shape as `reference.tiff` but in which each pixel value corresponds to either the left or right hemisphere. They are labeled 0 and 1 respectively
 * `meshes` A directory of mesh files \(as `.obj`\) for each brain region, defined by the unique region ID
 * `structures.json` A file describing the mapping of brain region ID to region name, and the hierarchy of brain structures
 * `metadata.json` A file containing the atlas metadata, such as the shape of the images, the anatomical orientation, and the details of the source of the atlas


### PR DESCRIPTION


## Description
I just added a quick description of the hemispheres.tiff file as this is omitted in the description of which files can be found in the atlas folder and what they are.
**What is this PR**
- [ x] Other (small update of documentation)

