### PR TITLE
Pin sphinx version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<=7.2.6
 pydata-sphinx-theme
 myst-parser
 numpydoc


### PR DESCRIPTION
Pinning Sphinx to 7.2 or below seems to be necessary due to some [recent changes with Sphinx affecting ablog](https://github.com/sunpy/ablog/issues/277). Hopefully this will be fixed upstream, but in the meantime this seems to sort out the problem. 