### PR TITLE
Document cellfinder_download CLI tool

### DIFF
--- a/docs/source/documentation/brainglobe-workflows/brainmapper/cli.md
+++ b/docs/source/documentation/brainglobe-workflows/brainmapper/cli.md
@@ -5,7 +5,7 @@
 To run `brainmapper`, use this general syntax
 
 ```bash
-    brainmapper -s signal_channel_images  optional_signal_channel_images -b background_channel_images -o /path/to/output_directory -v 5 2 2 --orientation asl
+brainmapper -s signal_channel_images  optional_signal_channel_images -b background_channel_images -o /path/to/output_directory -v 5 2 2 --orientation asl
 ```
 
 :::{hint}

--- a/docs/source/documentation/brainglobe-workflows/brainmapper/index.md
+++ b/docs/source/documentation/brainglobe-workflows/brainmapper/index.md
@@ -20,6 +20,11 @@ error-messages
 /documentation/cellfinder/user-guide/training/index
 ```
 
+:::{note}  If you would like to use `brainmapper` offline, you will need to 
+[download an appropriate atlas](/documentation/brainglobe-atlasapi/usage/command-line-interface) and 
+[download a pre-trained cellfinder model](/documentation/cellfinder/user-guide/cellfinder-download) in advance. 
+:::
+
 ## Tutorials
 
 ```{toctree}

--- a/docs/source/documentation/cellfinder/index.md
+++ b/docs/source/documentation/cellfinder/index.md
@@ -45,6 +45,7 @@ installation
 user-guide/napari-plugin/index
 user-guide/cellfinder-core
 user-guide/training/index
+user-guide/cellfinder-download
 ```
 
 ## Troubleshooting

--- a/docs/source/documentation/cellfinder/installation.md
+++ b/docs/source/documentation/cellfinder/installation.md
@@ -1,11 +1,10 @@
-# Requirements
+# Installation
 
+## Requirements
 `cellfinder` should run on most machines, but for routine use on large datasets, you will need a fairly high-powered computer (see the guide to [Speeding up cellfinder](/documentation/cellfinder/troubleshooting/speed-up) for details).
 
 Using an NVIDIA GPU will speed up cell classification considerably.
 See [setting up your GPU](/documentation/setting-up/gpu) for details.
-
-## Installation
 
 To use cellfinder, you will need to have Python on your machine.
 Your machine may already have Python installed, but we recommend installing miniconda.
@@ -17,13 +16,14 @@ You can use `pip` from inside your activated Python environment to install the `
 Make sure to install version `1.0.0` or later!
 
 ```bash
-pip install cellfinder>=1.0.0 # Run this if you only want the Python API (for use in scripts)
-pip install cellfinder[napari]>=1.0.0 # Run this if you want to install the API and the napari plugin
+pip install cellfinder # Run this if you only want the Python API (for use in scripts)
+pip install cellfinder[napari] # Run this if you want to install the API and the napari plugin
 ```
 
-### Installing BrainGlobe Atlases
+### Downloading pre-trained models
 
-To install download BrainGlobe atlases in advance, please see the guide to [the BrainGlobe Atlas API command-line interface](/documentation/brainglobe-atlasapi/usage/command-line-interface).
+If you would like to download the pre-trained models in advance (otherwise they will download as needed), 
+please see [Downloading the pre-trained model in advance](user-guide/cellfinder-download).
 
 ### Installing `brainmapper`
 

--- a/docs/source/documentation/cellfinder/user-guide/cellfinder-download.md
+++ b/docs/source/documentation/cellfinder/user-guide/cellfinder-download.md
@@ -1,0 +1,15 @@
+# Downloading the pre-trained model in advance
+
+`cellfinder` will download the pre-trained model when it's needed. However, you may want to download this model in 
+advance to save time later, or if you know your internet connection will be disrupted. For this reason, cellfinder 
+comes with a command-line tool (`cellfinder_download`) to download a pre-trained model.
+
+To download the recommended model, just run `cellfinder_download`. However, you can also use the following options:
+
+* `--install-path` Use this flag to choose where you would like to download the model to, and also update the 
+cellfinder config file (at `~/.brainglobe/cellfinder/cellfinder.conf.custom`) to point to this location. 
+By default, models are saved in your home directory at `~/.brainglobe/cellfinder/models`.
+* `--model` Use this flag to specify a specific model. The default model is `restnet50_tv`, which is (currently) the 
+only recommended model to use. 
+* `--no-amend-config` Use this flag to ensure the cellfinder config file is not updated (useful if you just want to 
+download the trained model)


### PR DESCRIPTION
This PR documents the `cellfinder_download` tool. I also fixed some little things I came across:
- Adds a suggestion that users may want to pre download models/atlases in the `brainmapper` docs
- Removes outdated reference to downloading atlases for `cellfinder`
- Removes the version number specification for installing `cellfinder` (the latest should be downloading anyway)
- Fixes a minor formatting issue in the `brainmapper` CLI example

Closes #176 