### PR TITLE
Add list of citing papers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,4 @@ repos:
     rev: v2.2.6
     hooks:
       - id: codespell
+        exclude: docs/source/publications.md # lots of author names

--- a/docs/source/publications.md
+++ b/docs/source/publications.md
@@ -1,4 +1,4 @@
-# Publications
+# BrainGlobe publications
 
 Brainreg & brainglobe-segmentation (formerly brainreg-segment):
 > Tyson, A. L., V&eacute;lez-Fort, M.,  Rousseau, C. V., Cossell, L., Tsitoura, C., Lenzi, S. C., Obenhaus, H. A., Claudi, F., Branco, T., Margrie, T. W. (2022) “Accurate determination of marker location within whole-brain microscopy images" Scientific Reports, [doi.org/10.1038/s41598-021-04676-9](https://doi.org/10.1038/s41598-021-04676-9)
@@ -13,6 +13,293 @@ Brainrender:
 BrainGlobe Atlas API:
 > Claudi, F., Petrucco, L., Tyson, A. L., Branco, T., Margrie, T. W., Portugues, R. (2020) &quot;BrainGlobe Atlas API: a common interface for neuroanatomical atlases&quot; <i>Journal of Open Source Software</i>, 5(54), 2668 [doi.org/10.21105/joss.02668](https://doi.org/10.21105/joss.02668)
 
+# Publications citing BrainGlobe
+**This list is automatically generated from Google Scholar**
 
-aMAP (brainreg predecessor)
-> Niedworok, C.J, Brown, A.P.Y, Jorge Cardoso, M., Osten, P., Ourselin, S., Modat, M., Margrie, T.W. (2016) "aMAP is a validated pipeline for registration and segmentation of high-resolution mouse brain data" <i>Nature Communications</i> 7, 1187. [doi.org/10.1038/ncomms11879](https://doi.org/10.1038/ncomms11879)
+[//]: # (To generate this, export a list from google scholar as bibtex, then convert to html)
+
+[//]: # (&#40;https://asouqi.github.io/bibtex-converter/&#41; then md &#40;https://codebeautify.org/html-to-markdown&#41&#41;. This is a low-tech &#41;)
+
+[//]: # (&#40;way of doing it, but it's much simpler than via the CLIs I found.&#41;)
+
+AlSubaie, R., Wee, R. W., Ritoux, A., Mishchanchuk, K., Passlack, J., Regester, D., & MacAskill, A. F. (2021). Control of parallel hippocampal output pathways by amygdalar long-range inhibition. _Elife_, _10_, e74758.
+
+An, X., Matho, K., Li, Y., Mohan, H., Xu, X. H., Whishaw, I. Q., Kepecs, A., & Huang, Z. J. (2022). A cortical circuit for orchestrating oromanual food manipulation. _BioRxiv_, 2022–12.
+
+Argunşah, A. Ö., Erdil, E., Ghani, M. U., Ramiro-Cortés, Y., Hobbiss, A. F., Karayannis, T., Çetin, M., Israely, I., & Ünay, D. (2022). An interactive time series image analysis software for dendritic spines. _Scientific Reports_, _12_(1), 12405.
+
+Arshadi, C., Günther, U., Eddison, M., Harrington, K. I., & Ferreira, T. A. (2021). SNT: a unifying toolbox for quantification of neuronal anatomy. _Nature Methods_, _18_(4), 374–377.
+
+Athey, T. L., Wright, M. A., Pavlovic, M., Chandrashekhar, V., Deisseroth, K., Miller, M. I., & Vogelstein, J. T. (2023). Brainline: An open pipeline for connectivity analysis of heterogeneous whole-brain fluorescence volumes. _Neuroinformatics_, _21_(4), 637–639.
+
+Bao, R., Al-Shakarji, N. M., Bunyak, F., & Palaniappan, K. (2021). Dmnet: Dual-stream marker guided deep network for dense cell segmentation and lineage tracking. _Proceedings of the IEEE/CVF International Conference on Computer Vision_, 3361–3370.
+
+Beyer, J., Troidl, J., Boorboor, S., Hadwiger, M., Kaufman, A., & Pfister, H. (2022). A survey of visualization and analysis in high-resolution connectomics. _Computer Graphics Forum_, _41_(3), 573–607.
+
+Bhatia, H. S., Brunner, A.-D., Öztürk, F., Kapoor, S., Rong, Z., Mai, H., Thielert, M., Ali, M., Al-Maskari, R., Paetzold, J. C., & others. (2022). Spatial proteomics in three-dimensional intact specimens. _Cell_, _185_(26), 5040–5058.
+
+(BICCN), B. I. C. C. N., Adkins, R. S., Aldridge, A. I., Allen, S., Ament, S. A., An, X., Armand, E., Ascoli, G. A., Bakken, T. E., Bandrowski, A., & others. (2020). A multimodal cell census and atlas of the mammalian primary motor cortex. _Biorxiv_, 2020–10.
+
+Bimbard, C, Takács, F., Fabre, J., Melin, M., O’Neill, N., Robacha, M., Street, J., van Beest, E., Churchland, A., Harris, K., & others. (2023). Reusable, flexible, and lightweight chronic implants for Neuropixels probes. _BioRxiv_.
+
+Bimbard, Célian, Sit, T. P., Lebedeva, A., Reddy, C. B., Harris, K. D., & Carandini, M. (2023). Behavioral origin of sound-evoked activity in mouse visual cortex. _Nature Neuroscience_, _26_(2), 251–258.
+
+Bimbard, Célian, Takács, F., Catarino, J., Fabre, J., Gupta, S., Lenzi, S., Melin, M., O’Neill, N., Robacha, M., Street, J., & others. (2023). An adaptable, reusable, and light implant for chronic Neuropixels probes. _BioRxiv_.
+
+Birman, D., Yang, K. J., West, S. J., Karsh, B., Browning, Y., Laboratory, I. B., Siegle, J. H., & Steinmetz, N. A. (2023). Pinpoint: trajectory planning for multi-probe electrophysiology and injections in an interactive web-based 3D environment. _BioRxiv_.
+
+Blackmore, M., Batsel, E., & Tsoulfas, P. (2021). Widening spinal injury research to consider all supraspinal cell types: Why we must and how we can. _Experimental Neurology_, _346_, 113862.
+
+Blixhavn, C. H., Reiten, I., Kleven, H., Øvsthus, M., Yates, S. C., Schlegel, U., Puchades, M. A., Schmid, O., Bjaalie, J. G., Bjerke, I. E., & others. (2024). The Locare workflow: representing neuroscience data locations as geometric objects in 3D brain atlases. _Frontiers in Neuroinformatics_, _18_, 1284107.
+
+Bonapersona, V, Schuler, H., Damsteegt, R., Adolfs, Y., Pasterkamp, R., van den Heuvel, M., Joëls, M., & Sarabdjitsingh, R. (2021). The mouse brain after foot-shock in 4D: temporal dynamics at a single-cell resolution. _BioRxiv_, 2021–05.
+
+Bonapersona, Valeria, Schuler, H., Damsteegt, R., Adolfs, Y., Pasterkamp, R. J., van den Heuvel, M. P., Joëls, M., & Sarabdjitsingh, R. A. (2022). The mouse brain after foot shock in four dimensions: Temporal dynamics at a single-cell resolution. _Proceedings of the National Academy of Sciences_, _119_(8), e2114002119.
+
+Brown, A. P., Cossell, L., Strom, M., Tyson, A. L., Vélez-Fort, M., & Margrie, T. W. (2021). Analysis of segmentation ontology reveals the similarities and differences in connectivity onto L2/3 neurons in mouse V1. _Scientific Reports_, _11_(1), 4983.
+
+Buck, S. A., Rubin, S. A., Kunkhyen, T., Treiber, C. D., Xue, X., Fenno, L. E., Mabry, S. J., Sundar, V. R., Yang, Z., Shah, D., & others. (2023). Sexually dimorphic mechanisms of VGLUT-mediated protection from dopaminergic neurodegeneration. _BioRxiv_.
+
+Campagner, D., Vale, R., Tan, Y. L., Iordanidou, P., Pavón Arocas, O., Claudi, F., Stempel, A. V., Keshavarzi, S., Petersen, R. S., Margrie, T. W., & others. (2020). A cortico-collicular circuit for accurate orientation to shelter during escape. _BioRxiv_, 2020–05.
+
+Campagner, D., Vale, R., Tan, Y. L., Iordanidou, P., Pavón Arocas, O., Claudi, F., Stempel, A. V., Keshavarzi, S., Petersen, R. S., Margrie, T. W., & others. (2023). A cortico-collicular circuit for orienting to shelter during escape. _Nature_, _613_(7942), 111–119.
+
+Chalatsi, T., Fernandez, L. M., Scholler, J., Batti, L., Kolaxi, A., Restivo, L., Lüthi, A., Mameli, M., & Nikoletopoulou, V. (2022). Autophagy in parvalbumin interneurons is required for inhibitory transmission and memory via regulation of synaptic proteostasis. _BioRxiv_, 2022–10.
+
+Chen, R., Liu, M., Chen, W., Wang, Y., & Meijering, E. (2023). Deep learning in mesoscale brain microscopy image analysis: A review. _Computers in Biology and Medicine_, 107617.
+
+Chini, M., Hnida, M., Kostka, J. K., Chen, Y.-N., & Hanganu-Opatz, I. L. (2023). Extreme distributions in the preconfigured developing brain. _BioRxiv_, 2023–11.
+
+Chini, M., Pfeffer, T., & Hanganu-Opatz, I. (2022). An increase of inhibition drives the developmental decorrelation of neural activity. _Elife_, _11_, e78811.
+
+Chini, M., Pfeffer, T., & Hanganu-Opatz, I. L. (2021). Developmental increase of inhibition drives decorrelation of neural activity. _BioRxiv_, 2021–07.
+
+Chiu, C.-L., Clack, N., & others. (2022). Napari: A Python multi-dimensional image viewer platform for the research community. _Microscopy and Microanalysis_, _28_(S1), 1576–1577.
+
+Claar, L. D., Rembado, I., Kuyat, J. R., Russo, S., Marks, L. C., Olsen, S. R., & Koch, C. (2023). Cortico-thalamo-cortical interactions modulate electrically evoked EEG responses in mice. _ELife_, _12_, RP84630.
+
+Claudi, F., Petrucco, L., Tyson, A., Branco, T., Margrie, T., & Portugues, R. (2020). BrainGlobe Atlas API: a common interface for neuroanatomical atlases. _Journal of Open Source Software_, _5_(54), 2668–2668.
+
+Claudi, F., Tyson, A. L., & Branco, T. (2020). Brainrender. _A Python Based Software for Visualisation of Neuroanatomical and Morphological Data. BioRxiv_, _23_.
+
+Claudi, F., Tyson, A. L., Petrucco, L., Margrie, T. W., Portugues, R., & Branco, T. (2021). Visualizing anatomically registered data with brainrender. _Elife_, _10_, e65751.
+
+Cramer, T., Gill, R., Thirouin, Z. S., Vaas, M., Sampath, S., Martineau, F., Noya, S. B., Panzanelli, P., Sudharshan, T. J., Colameo, D., & others. (2022). Cross-talk between GABAergic postsynapse and microglia regulate synapse loss after brain ischemia. _Science Advances_, _8_(9), eabj0112.
+
+Culp, A. (2023). _Cell Type Diversity in the Norepinephrine Signaling Network_ \[Phdthesis\]. Oregon Health.
+
+Datta, M. S., Chen, Y., Chauhan, S., Zhang, J., De La Cruz, E. D., Gong, C., & Tomer, R. (2023). Whole-brain mapping reveals the divergent impact of ketamine on the dopamine system. _Cell Reports_, _42_(12).
+
+Davoudian, P. A., Shao, L.-X., & Kwan, A. C. (2023). Shared and distinct brain regions targeted for immediate early gene expression by ketamine and psilocybin. _ACS Chemical Neuroscience_, _14_(3), 468–480.
+
+De Filippo, R., & Schmitz, D. (2023). Differential ripple propagation along the hippocampal longitudinal axis. _Elife_, _12_, e85488.
+
+Dehaqani, A. A., Michelon, F., Patella, P., Petrucco, L., Piasini, E., & Iurilli, G. (2024). A mechanosensory feedback that uncouples external and self-generated sensory responses in the olfactory cortex. _Cell Reports_, _43_(4).
+
+Dehaqani, A. A., Michelon, F., Petrucco, L., Patella, P., Piasini, E., & Iurilli, G. (2023). A mixed mechano-olfactory code for sniff-invariant odor representations. _BioRxiv_, 2023–04.
+
+Durand, S., Heller, G. R., Ramirez, T. K., Luviano, J. A., Williford, A., Sullivan, D. T., Cahoon, A. J., Farrell, C., Groblewski, P. A., Bennett, C., & others. (2023). Acute head-fixed recordings in awake mice with multiple Neuropixels probes. _Nature Protocols_, _18_(2), 424–457.
+
+Englund, M., James, S. S., Bottom, R., Huffman, K. J., Wilson, S. P., & Krubitzer, L. A. (2021). Comparing cortex-wide gene expression patterns between species in a common reference frame. _BioRxiv_, 2021–07.
+
+Esmaeili, V., Oryshchuk, A., Asri, R., Tamura, K., Foustoukos, G., Liu, Y., Guiet, R., Crochet, S., & Petersen, C. C. (2022). Learning-related congruent and incongruent changes of excitation and inhibition in distinct cortical areas. _PLoS Biology_, _20_(5), e3001667.
+
+Fanton, S., & Thompson, W. H. (2023). NetPlotBrain: A Python package for visualizing networks and brains. _Network Neuroscience_, _7_(2), 461–477.
+
+Farrell, J. S., Hwaun, E., Dudok, B., & Soltesz, I. (2024). Neural and behavioural state switching during hippocampal dentate spikes. _Nature_, 1–6.
+
+Fernholz, M. (2023). _A search for functional connectivity rules in the visual thalamus and hippocampus_ \[Phdthesis\]. lmu.
+
+Fiederling, F., Hammond, L. A., Ng, D., Mason, C., & Dodd, J. (2021). Tools for efficient analysis of neurons in a 3D reference atlas of whole mouse spinal cord. _Cell Reports Methods_, _1_(5).
+
+Fisher, J., Verhagen, M., Long, Z., Moissidis, M., Yan, Y., He, C., Wang, J., Micoli, E., Alastruey, C. M., Moors, R., & others. (2024). Cortical somatostatin long-range projection neurons and interneurons exhibit divergent developmental trajectories. _Neuron_, _112_(4), 558–573.
+
+Franceschini, A., Mazzamuto, G., Checcucci, C., Chicchi, L., Fanelli, D., Costantini, I., Passani, M. B., Silva, B. A., Pavone, F. S., & Silvestri, L. (2023). Brain-wide neuron quantification toolkit reveals strong sexual dimorphism in the evolution of fear memory. _Cell Reports_, _42_(8).
+
+Frankowski, J. C., Tierno, A., Pavani, S., Cao, Q., Lyon, D. C., & Hunt, R. F. (2022). Brain-wide reconstruction of inhibitory circuits after traumatic brain injury. _Nature Communications_, _13_(1), 3417.
+
+Fuglstad, J. G., Saldanha, P., Paglia, J., & Whitlock, J. R. (2023). Histological E-data registration in rodent brain spaces. _Elife_, _12_, e83496.
+
+Galloni, A. R., Ye, Z., & Rancz, E. (2022). Dendritic domain-specific sampling of long-range axons shapes feedforward and feedback connectivity of L5 neurons. _Journal of Neuroscience_, _42_(16), 3394–3405.
+
+Gerlei, K. Z., Brown, C. M., Sürmeli, G., & Nolan, M. F. (2021). Deep entorhinal cortex: from circuit organization to spatial cognition and memory. _Trends in Neurosciences_, _44_(11), 876–887.
+
+Greenstreet, F., Vergara, H. M., Pati, S., Schwarz, L., Wisdom, M., Marbach, F., Johansson, Y., Rollik, L., Moskovitz, T., Clopath, C., & others. (2022). Action prediction error: a value-free dopaminergic teaching signal that drives stable learning. _BiorXiv_, 2022–09.
+
+Gruver, K. (2023). _Purkinje cells converge non-randomly on neurons in the cerebellar nuclei_.
+
+Gruver, K. M., Jiao, J. W., Fields, E., Song, S., Sjöström, P. J., & Watt, A. J. (2023). Structured connectivity in the output of the cerebellar cortex. _BioRxiv_, 2023–03.
+
+Guo, S., Xue, J., Liu, J., Ye, X., Guo, Y., Liu, D., Zhao, X., Xiong, F., Han, X., & Peng, H. (2022). Smart imaging to empower brain-wide neuroscience at single-cell levels. _Brain Informatics_, _9_(1), 10.
+
+Hagihara, K. M., Bukalo, O., Zeller, M., Aksoy-Aksel, A., Karalis, N., Limoges, A., Rigg, T., Campbell, T., Mendez, A., Weinholtz, C., & others. (2021). Intercalated amygdala clusters orchestrate a switch in fear state. _Nature_, _594_(7863), 403–407.
+
+Hahn, J. D., & Duckworth, C. (2023). A brain flatmap data visualization tool for mouse, rat, and human. _Journal of Comparative Neurology_, _531_(10), 1008–1016.
+
+Jin, M., Nguyen, J. D., Weber, S. J., Mejias-Aponte, C. A., Madangopal, R., & Golden, S. A. (2022). Smart: An open-source extension of wholebrain for intact mouse brain registration and segmentation. _Eneuro_, _9_(3).
+
+Jones, A. (2023). _Probabilistic models for structured biomedical data_ \[Phdthesis\]. Princeton University.
+
+Jones, A., Cai, D., Li, D., & Engelhardt, B. E. (2023). Optimizing the design of spatial genomic studies. _BioRxiv_.
+
+Kaltenecker, D., Al-Maskari, R., Negwer, M., Hoeher, L., Kofler, F., Zhao, S., Todorov, M., Rong, Z., Paetzold, J. C., Wiestler, B., & others. (2024). Virtual reality-empowered deep-learning analysis of brain cells. _Nature Methods_, 1–10.
+
+Kantor, B., & Ben-Ami Bartal, I. (2023). Brainways: An AI-based Tool for Automated Registration, Quantification and Generation of Brain-wide Activity Networks Based on Fluorescence in Coronal Slices. _BioRxiv_, 2023–05.
+
+Keshavarzi, S., Bracey, E. F., Faville, R. A., Campagner, D., Tyson, A. L., Lenzi, S. C., Branco, T., & Margrie, T. W. (2021). The retrosplenial cortex combines internal and external cues to encode head velocity during navigation. _BioRxiv_, 2021–01.
+
+Keshavarzi, S., Bracey, E. F., Faville, R. A., Campagner, D., Tyson, A. L., Lenzi, S. C., Branco, T., & Margrie, T. W. (2022). Multisensory coding of angular head velocity in the retrosplenial cortex. _Neuron_, _110_(3), 532–543.
+
+Kintscher, M., Kochubey, O., & Schneggenburger, R. (2023). A striatal circuit balances learned fear in the presence and absence of sensory cues. _Elife_, _12_, e75703.
+
+Kostka, Johanna K, & Hanganu-Opatz, I. L. (2023). Olfactory-driven beta band entrainment of limbic circuitry during neonatal development. _The Journal of Physiology_, _601_(16), 3605–3630.
+
+Kostka, Johanna Katharina. (2022). _Olfactory entrainment of cortical-hippocampal networks during development_ \[Phdthesis\]. Staats-und Universitätsbibliothek Hamburg Carl von Ossietzky.
+
+Lauridsen, K., Ly, A., Prévost, E. D., McNulty, C., McGovern, D. J., Tay, J. W., Dragavon, J., & Root, D. H. (2022). A semi-automated workflow for brain Slice Histology Alignment, Registration, and Cell Quantification (SHARCQ). _Eneuro_, _9_(2).
+
+Lenzi, S. (2021). _A Role for the Tail of the Striatum in the Adaptive Control of Innate Escape Behaviour_ \[Phdthesis\]. UCL (University College London).
+
+Li, D. (2022). _Bistable Neural Dynamics Underlying Cognition and Spontaneous Activity: Computational Modeling and Empirical Analysis_ \[Phdthesis\]. Yale University.
+
+Lowet, A. S., Zheng, Q., Meng, M., Matias, S., Drugowitsch, J., & Uchida, N. (2023). Distributional Reinforcement Learning in the Mammalian Brain. _UniReps: The First Workshop on Unifying Representations in Neural Models_.
+
+Lowet, A. S., Zheng, Q., Meng, M., Matias, S., Drugowitsch, J., & Uchida, N. (2024). An opponent striatal circuit for distributional reinforcement learning. _BioRxiv_, 2024–01.
+
+Lu, T., Shinozaki, M., Nagoshi, N., Nakamura, M., & Okano, H. (2022). 3D imaging of supraspinal inputs to the thoracic and lumbar spinal cord mapped by retrograde tracing and light-sheet microscopy. _Journal of Neurochemistry_, _162_(4), 352–370.
+
+Lupori, L., & others. (2023). _Genetic and environmental factors regulating structure, function and plasticity of the visual cortex_.
+
+Lupori, L., Totaro, V., Cornuti, S., Ciampi, L., Carrara, F., Grilli, E., Viglione, A., Tozzi, F., Putignano, E., Mazziotti, R., & others. (2023). A comprehensive atlas of perineuronal net distribution and colocalization with parvalbumin in the adult mouse brain. _Cell Reports_, _42_(7).
+
+MacDowell, C. J., Libby, A., Jahn, C. I., Tafazoli, S., & Buschman, T. J. (2023). Multiplexed subspaces route neural activity across brain-wide networks. _BioRxiv_.
+
+manuscript editors, P., coordination, A., data analysis Armand Ethan 42 Yao Zizhen 5, I., seq data ATAC-generation, processing Fang Rongxin 45 Hou Xiaomeng 10 Lucero Jacinta D. 18 Osteen Julia K. 18 Pinto-Duarte Antonio 18 Poirion Olivier 10 Preissl Sebastian 10 Wang Xinxin 10 97 97, retro-seq data Epi-generation, processing Dominguez Bertha 53 Ito-Cole Tony 1 Jacobs Matthew 1 Jin Xin 54 99 100 99 100 Lee Cheng-Ta 53 Lee Kuo-Fen 53 Miyazaki Paula Assakura 1 Pang Yan 1 Rashid Mohammad 1 Smith Jared B. 54 Vu Minh 1 Williams Elora 54, & others. (2021). A multimodal cell census and atlas of the mammalian primary motor cortex. _Nature_, _598_(7879), 86–102.
+
+McGovern, D. J., Polter, A. M., Prévost, E. D., Ly, A., McNulty, C. J., Rubinstein, B., & Root, D. H. (2023). Ventral tegmental area glutamate neurons establish a mu-opioid receptor gated circuit to mesolimbic dopamine neurons and regulate opioid-seeking behavior. _Neuropsychopharmacology_, _48_(13), 1889–1900.
+
+McKenna, K., Prasad, S., Cooper, J., King, A. M., Shahzeidi, S., Mittal, J., Zalta, M., Mittal, R., & Eshraghi, A. A. (2024). Incidence of Otolaryngological Manifestations in Individuals with Autism Spectrum Disorder: A Special Focus on Auditory Disorders. _Audiology Research_, _14_(1), 35–61.
+
+Mitrevica, Z., & Murray, A. J. (2023). Speed-independent modulation of locomotor gait preference by sensory feedback in mice. _BioRxiv_, 2023–03.
+
+Mohan, H., An, X., Xu, X. H., Kondo, H., Zhao, S., Matho, K. S., Wang, B.-S., Musall, S., Mitra, P., & Huang, Z. J. (2023). Cortical glutamatergic projection neuron types contribute to distinct functional subnetworks. _Nature Neuroscience_, _26_(3), 481–494.
+
+Morimoto, M. M., Uchishiba, E., & Saleem, A. B. (2021). Organization of feedback projections to mouse primary visual cortex. _IScience_, _24_(5).
+
+Muñoz-Castañeda, R., Zingg, B., Matho, K. S., Chen, X., Wang, Q., Foster, N. N., Li, A., Narasimhan, A., Hirokawa, K. E., Huo, B., & others. (2021). Cellular anatomy of the mouse primary motor cortex. _Nature_, _598_(7879), 159–166.
+
+Negwer, M., Bosch, B., Bormann, M., Hesen, R., Lütje, L., Aarts, L., Rossing, C., Nadif Kasri, N., & Schubert, D. (2023). FriendlyClearMap: an optimized toolkit for mouse brain mapping and analysis. _GigaScience_, _12_, giad035.
+
+Newmaster, K. T., Kronman, F. A., Wu, Y., & Kim, Y. (2022). Seeing the forest and its trees together: implementing 3D light microscopy pipelines for cell type mapping in the mouse brain. _Frontiers in Neuroanatomy_, _15_, 787601.
+
+Nyberg, N., Duvelle, É., Barry, C., & Spiers, H. J. (2022). Spatial goal coding in the hippocampal formation. _Neuron_, _110_(3), 394–422.
+
+Paglia, J., Saldanha, P., Fuglstad, J. G., & Whitlock, J. R. (2021). TRACER: a toolkit to register and visualize anatomical coordinates in the rat brain. _BioRxiv_, 2021–10.
+
+Palchaudhuri, S., Osypenko, D., Kochubey, O., & Schneggenburger, R. (2023). An insular cortex to lateral amygdala pathway in fear learning. _BioRxiv_, 2023–01.
+
+Parks, D. F., Schneider, A. M., Xu, Y., Brunwasser, S. J., Funderburk, S., Thurber, D., Blanche, T., Dyer, E. L., Haussler, D., & Hengen, K. B. (2023). A non-oscillatory, millisecond-scale embedding of brain state provides insight into behavior. _BioRxiv_.
+
+Patel, V. (2021). _Deep Learning model to Automate the process of mapping Cancer Cells to Cell Lines & Cancer Types from Single Cell RNA-Seq Data_.
+
+Pavón Arocas, O. (2022). _Biophysical properties and gene expression profile of single periaqueductal gray neurons_ \[Phdthesis\]. UCL (University College London).
+
+Perens, J. (2021). _Enabling multimodal whole-brain investigation for drug discovery_.
+
+Perens, J., & Hecksher-Sørensen, J. (2022). Digital brain maps and virtual neuroscience: An emerging role for light-sheet fluorescence microscopy in drug development. _Frontiers in Neuroscience_, _16_, 866884.
+
+Petrucco, L., Lavian, H., Wu, Y. K., Svara, F., Štih, V., & Portugues, R. (2023). Neural dynamics and architecture of the heading direction circuit in zebrafish. _Nature Neuroscience_, _26_(5), 765–773.
+
+Pochinok, I., Stöber, T. M., Triesch, J., Chini, M., & Hanganu-Opatz, I. L. (2024). A developmental increase of inhibition promotes the emergence of hippocampal ripples. _Nature Communications_, _15_(1), 738.
+
+Pouchelon, G., Dwivedi, D., Bollmann, Y., Agba, C. K., Xu, Q., Mirow, A. M., Kim, S., Qiu, Y., Sevier, E., Ritola, K. D., & others. (2021). The organization and development of cortical interneuron presynaptic circuits are area specific. _Cell Reports_, _37_(6).
+
+Prévost, E. D., Phillips, A., Lauridsen, K., Enserro, G., Rubinstein, B., Alas, D., McGovern, D. J., Ly, A., Banks, M., McNulty, C., & others. (2023). Monosynaptic inputs to ventral tegmental area glutamate and GABA co-transmitting neurons. _BioRxiv_.
+
+Qian, K., Friedman, B., Takatoh, J., Wang, F., Kleinfeld, D., & Freund, Y. (2023). CellBoost: A pipeline for machine assisted annotation in neuroanatomy. _BioRxiv_, 2023–09.
+
+Regev, A. (2021). _A multimodal cell census and atlas of the mammalian primary motor cortex_.
+
+Ruff, K. M., Choi, Y. H., Cox, D., Ormsby, A. R., Myung, Y., Ascher, D. B., Radford, S. E., Pappu, R. V., & Hatters, D. M. (2022). Sequence grammar underlying the unfolding and phase separation of globular proteins. _Molecular Cell_, _82_(17), 3193–3208.
+
+Sanchez-Arias, J. C., Carrier, M., Frederiksen, S. D., Shevtsova, O., McKee, C., van der Slagt, E., Gonçalves de Andrade, E., Nguyen, H. L., Young, P. A., Tremblay, M., & others. (2021). A Systematic, Open-Science Framework for Quantification of Cell-Types in Mouse Brain Sections Using Fluorescence Microscopy. _Frontiers in Neuroanatomy_, _15_, 722443.
+
+Scholler, J., Jonsson, J., Jordá-Siquier, T., Gantar, I., Batti, L., Cheeseman, B. L., Pagès, S., Sbalzarini, I. F., & Lamy, C. M. (2023). Efficient image analysis for large-scale next generation histopathology using pAPRica. _BioRxiv_, 2023–01.
+
+Schweihoff, J. F. (2022). _Ai-based, behavior dependent approaches for connectomic reconstruction of neuronal circuits_ \[Phdthesis\]. Universitäts-und Landesbibliothek Bonn.
+
+Siu, P. H., Müller, E., Zerbi, V., Aquino, K., & Fulcher, B. D. (2022). Extracting dynamical understanding from neural-mass models of mouse cortex. _Frontiers in Computational Neuroscience_, _16_, 847336.
+
+Soltwedel, J., Suckert, T., Beyreuther, E., Schneider, M., Boucsein, M., Bodenstein, E., Nexhipi, S., Stolz-Kieslich, L., Krause, M., von Neubeck, C., & others. (2023). Slice2Volume: Fusion of multimodal medical imaging and light microscopy data of irradiation-injured brain tissue in 3D. _Radiotherapy and Oncology_, _182_, 109591.
+
+Szabo, G. G., Farrell, J. S., Dudok, B., Hou, W.-H., Ortiz, A. L., Varga, C., Moolchand, P., Gulsever, C. I., Gschwind, T., Dimidschstein, J., & others. (2022). Ripple-selective GABAergic projection cells in the hippocampus. _Neuron_, _110_(12), 1959–1977.
+
+Szelenyi, E. R., Navarrete, J. S., Murry, A. D., Zhang, Y., Girven, K. S., Kuo, L., Cline, M. M., Bernstein, M. X., Burdyniuk, M., Bowler, B., & others. (2023). An arginine-rich nuclear localization signal (ArgiNLS) strategy for streamlined image segmentation of single-cells. _BioRxiv_.
+
+Takatoh, J., Park, J. H., Lu, J., Li, S., Thompson, P., Han, B.-X., Zhao, S., Kleinfeld, D., Friedman, B., & Wang, F. (2021). Constructing an adult orofacial premotor atlas in Allen mouse CCF. _Elife_, _10_.
+
+Takatoh, J., Prevosto, V., Thompson, P., Lu, J., Chung, L., Harrahill, A., Li, S., Zhao, S., He, Z., Golomb, D., & others. (2022). The whisking oscillator circuit. _Nature_, _609_(7927), 560–568.
+
+Tantirigama, M. L., Schoenherr, A., Moreno-Velasquez, L., Faiss, L., Rost, B. R., Larkum, M. E., Judkewitz, B., Stumpenhorst, K., Rivalan, M., Winter, Y., & others. (2023). Binge Feeding Promotes Appetite via Modulating Olfactory Flavor Representation. _BioRxiv_, 2023–10.
+
+Taylor, D. (2023). _A brainstem circuit mechanism for coordinating the head and eyes during gaze movements_ \[Phdthesis\]. University of California, San Francisco.
+
+Terstege, D. J., & Epp, J. R. (2022). Network neuroscience untethered: brain-wide immediate early gene expression for the analysis of functional connectivity in freely behaving animals. _Biology_, _12_(1), 34.
+
+Terstege, D. J., Oboh, D. O., & Epp, J. R. (2022). FASTMAP: Open-source flexible atlas segmentation tool for multi-area processing of biological images. _ENeuro_, _9_(2).
+
+Thompson, E. (2024). _Subcortical circuits for procedural learning and memory_ \[Phdthesis\]. UCL (University College London).
+
+Tillmann, J. F. (n.d.). _Ai-based, behavior dependent approaches for connectomic reconstruction of neuronal circuits_ \[Phdthesis\]. Dissertation, Bonn, Rheinische Friedrich-Wilhelms-Universität, 2022.
+
+Toubal, I. E., Al-Shakarji, N., Cornelison, D., & Palaniappan, K. (2023). Ensemble deep learning object detection fusion for cell tracking, mitosis, and lineage. _IEEE Open Journal of Engineering in Medicine and Biology_.
+
+Tran-Van-Minh, A., Ye, Z., & Rancz, E. (2023). Quantitative analysis of rabies virus-based synaptic connectivity tracing. _PLoS One_, _18_(3), e0278053.
+
+Tsoi, S. Y., Öncül, M., Svahn, E., Robertson, M., Bogdanowicz, Z., McClure, C., & Sürmeli, G. (2021). Telencephalic outputs from the medial entorhinal cortex are copied directly to the hippocampus. _BioRxiv_, 2021–03.
+
+Tsoi, S. Y., Öncül, M., Svahn, E., Robertson, M., Bogdanowicz, Z., McClure, C., & Sürmeli, G. (2022). Telencephalic outputs from the medial entorhinal cortex are copied directly to the hippocampus. _Elife_, _11_, e73162.
+
+Tyson, A. L., & Margrie, T. W. (2022). Mesoscale microscopy and image analysis tools for understanding the brain. _Progress in Biophysics and Molecular Biology_, _168_, 81–93.
+
+Tyson, A. L., Rousseau, C. V., Niedworok, C. J., Keshavarzi, S., Tsitoura, C., Cossell, L., Strom, M., & Margrie, T. W. (2021). A deep learning algorithm for 3D cell detection in whole mouse brain image datasets. _PLoS Computational Biology_, _17_(5), e1009074.
+
+Tyson, A. L., Vélez-Fort, M., Rousseau, C. V., Cossell, L., Tsitoura, C., Lenzi, S. C., Obenhaus, H. A., Claudi, F., Branco, T., & Margrie, T. W. (2022). Accurate determination of marker location within whole-brain microscopy images. _Scientific Reports_, _12_(1), 867.
+
+Tyson, A. L., Vélez-Fort, M., Rousseau, C. V., Cossell, L., Tsitoura, C., Obenhaus, H. A., Claudi, F., Lenzi, S. C., Branco, T., & Margrie, T. W. (2021). Tools for accurate post hoc determination of marker location within whole-brain microscopy images. _BioRxiv_, 2021–05.
+
+Vohra, S. K., Harth, P., Isoe, Y., Bahl, A., Fotowat, H., Engert, F., Hege, H.-C., & Baum, D. (2023). A visual interface for exploring hypotheses about neural circuits. _IEEE Transactions on Visualization and Computer Graphics_.
+
+Wagner, R., & Rohr, K. (2022). Cellcentroidformer: Combining self-attention and convolution for cell detection. _Annual Conference on Medical Image Understanding and Analysis_, 212–222.
+
+Walker, L. A., Williams, J. S., Li, Y., Roossien, D. H., Lee, W. J., Michki, N. S., & Cai, D. (2022). ngauge: Integrated and extensible neuron morphology analysis in python. _Neuroinformatics_, _20_(3), 755–764.
+
+Wang, L.-W., Wu, Y.-L., Lee, C.-L., Cheng, C.-C., Lu, K.-Y., Tsai, J.-H., Lin, Y.-H., Hsu, C.-H., Kuo, T.-H., & Chu, L.-A. (2023). A Weakly Supervised U-Net Model for Precise Whole Brain Immunolabeled Cell Detection. _BioRxiv_, 2023–03.
+
+Wang, Z., Romanski, A., Mehra, V., Wang, Y., Brannigan, M., Campbell, B. C., Petsko, G. A., Tsoulfas, P., & Blackmore, M. G. (2022). Brain-wide analysis of the supraspinal connectome reveals anatomical correlates to functional recovery after spinal injury. _Elife_, _11_, e76254.
+
+Wang, Z., Romanski, A., Mehra, V., Wang, Y., Campbell, B. C., Petsko, G. A., Tsoulfas, P., & Blackmore, M. (2021). Brain-wide quantification of the supraspinal connectome. _BioRxiv_, 2021–06.
+
+Weiler, S., Rahmati, V., Isstas, M., Wutke, J., Stark, A. W., Franke, C., Graf, J., Geis, C., Witte, O. W., Hübener, M., & others. (2024). A primary sensory cortical interareal feedforward inhibitory circuit for tacto-visual integration. _Nature Communications_, _15_(1), 3081.
+
+Weiler, S., Teichert, M., & Margrie, T. W. (2024). Layer 6 corticocortical cells dominate the anatomical organization of intra and interhemispheric feedback. _BioRxiv_, 2024–05.
+
+Wilde, M., Constantin, L., Thorne, P. R., Montgomery, J. M., Scott, E. K., & Cheyne, J. E. (2022). Auditory processing in rodent models of autism: a systematic review. _Journal of Neurodevelopmental Disorders_, _14_(1), 48.
+
+Xie, Z., Wang, M., Liu, Z., Shang, C., Zhang, C., Sun, L., Gu, H., Ran, G., Pei, Q., Ma, Q., & others. (2021). Transcriptomic encoding of sensorimotor transformation in the midbrain. _Elife_, _10_, e69825.
+
+Yang, W., Kanodia, H., & Arber, S. (2023). Structural and functional map for forelimb movement phases between cortex and medulla. _Cell_, _186_(1), 162–177.
+
+Zahler, S. H., Taylor, D. E., Wright, B. S., Wong, J. Y., Shvareva, V. A., Park, Y. A., & Feinberg, E. H. (2023). Hindbrain modules differentially transform activity of single collicular neurons to coordinate movements. _Cell_, _186_(14), 3062–3078.
+
+Zhang, Y., Ackels, T., Pacureanu, A., Zdora, M.-C., Bonnin, A., Schaefer, A. T., & Bosch, C. (2022). Sample preparation and warping accuracy for correlative multimodal imaging in the mouse olfactory bulb using 2-photon, synchrotron x-ray and volume electron microscopy. _Frontiers in Cell and Developmental Biology_, _10_, 880696.
+
+Zhou, H., Li, Y., Wen, W., Yang, H., Ma, Y., & Chen, M. (2024). Accurately 3D neuron localization using 2D conv-LSTM super-resolution segmentation network. _IET Image Processing_, _18_(2), 535–547.
+
+Zhu, Y., Wang, G., Kolluru, C., Gu, Y., Gao, H., Zhang, J., Wang, Y., Wilson, D. L., Zhu, X., Flask, C. A., & others. (n.d.). _This manuscript was submitted to JCBFM for review on Nov 3, 2022._
+
+Zhu, Y., Wang, G., Kolluru, C., Gu, Y., Gao, H., Zhang, J., Wang, Y., Wilson, D. L., Zhu, X., Flask, C. A., & others. (2023). Transport pathways and kinetics of cerebrospinal fluid tracers in mouse brain observed by dynamic contrast-enhanced MRI. _Scientific Reports_, _13_(1), 13882.
+
+Zhukovskaya, A., Zimmerman, C. A., Willmore, L., Janarthanan, S. N., Falkner, A. L., & Witten, I. B. (2023). Differences in an aversive teaching signal produce brainwide and behavioral substrates of susceptibility. _BioRxiv_, 2023–11.
+
+Zimmerman, C. A., Pan-Vazquez, A., Wu, B., Keppler, E. F., Guthman, E. M., Fetcho, R. N., Bolkan, S. S., McMannon, B., Lee, J., Hoag, A. T., & others. (2023). A neural mechanism for learning from delayed postingestive feedback. _BioRxiv_.


### PR DESCRIPTION
Creating a list of papers citing BrainGlobe tools automatically is v. complicated (we tried before), but I came up with a low-tech way:

- Export a list from google scholar as bibtex
- Convert to html (https://asouqi.github.io/bibtex-converter/)
- Convert html to md (https://codebeautify.org/html-to-markdown&#41)

This takes 2 mins and is much easier than any CLIs or Python tools I found. It needs to be updated, but it can be done e.g. yearly.

I also removed the aMAP publication, because it doesn't fall under the BrainGlobe umbrella (although we still ask brainreg users to cite it). 