### PR TITLE
Update brainglobe-utils image IO docs

### DIFF
--- a/docs/source/documentation/brainglobe-utils/image_io.md
+++ b/docs/source/documentation/brainglobe-utils/image_io.md
@@ -1,27 +1,27 @@
-# image_io
+# Image IO submodule
 
-`image_io` provides various options to load and save image data. 
+The image IO submodule provides various options to load and save image data. 
 It supports common formats like `tiff`, `nrrd` and `nifti`.
 
 ## Installation
 
-`image_io` is provided as part of `brainglobe_utils` which comes with the one-line BrainGlobe install (`pip install brainglobe`).
+The image IO submodule is provided as part of `brainglobe_utils` which comes with the one-line BrainGlobe install (`pip install brainglobe`).
 It will also be fetched by most of our tools if you decide to install them as standalone.
 
 ## Loading images
 
-All options to load images are provided under `brainglobe_utils.image_io.load`. 
+All options to load images are provided under `brainglobe_utils.IO.image.load`. 
 For example, the general purpose `load_any` function which can load many common file formats:
 
 ```python
-from brainglobe_utils.image_io import load
+from brainglobe_utils.IO.image import load
 load.load_any('mydata.tif')
 ```
 
 There are also functions specific to particular file formats:
 
 ```python
-from brainglobe_utils.image_io import load
+from brainglobe_utils.IO.image import load
 
 # tiff
 load.load_img_stack('mydata.tif', x_scaling_factor=1, y_scaling_factor=1, z_scaling_factor=1)
@@ -36,20 +36,28 @@ load.load_nrrd('mydata.nrrd')
 load.load_nii('mydata.nii')
 ```
 
+Or to load a directory containing a series of 2D tiffs as a dask array:
+
+```python
+from brainglobe_utils.IO.image.load import read_with_dask
+
+signal_array = read_with_dask("/path/to/image_directory")
+```
+
 ## Saving images
 
-All options to save images are provided under `brainglobe_utils.image_io.save`. 
+All options to save images are provided under `brainglobe_utils.IO.image.save`. 
 For example, the general purpose `save_any` function which can save a numpy array to many common file formats:
 
 ```python
-from brainglobe_utils.image_io import save
+from brainglobe_utils.IO.image import save
 save.save_any(my_array, 'mydata.tif')
 ```
 
 There are also functions specific to particular file formats:
 
 ```python
-from brainglobe_utils.image_io import save
+from brainglobe_utils.IO.image import save
 
 # tiff
 save.to_tiff(my_array, 'mydata.tif')

--- a/docs/source/documentation/brainglobe-utils/index.md
+++ b/docs/source/documentation/brainglobe-utils/index.md
@@ -1,0 +1,13 @@
+# brainglobe-utils
+
+`brainglobe-utils` contains various functions and classes used by many BrainGlobe tools. Some functionality may 
+also be used directly. For more details, please see the specific pages:
+
+## User guide
+```{toctree}
+:maxdepth: 1
+citation-module
+image_io
+```
+:::{note}  The majority of the `brainglobe-utils` package is not yet documented here.
+:::

--- a/docs/source/documentation/cellfinder/user-guide/cellfinder-core.md
+++ b/docs/source/documentation/cellfinder/user-guide/cellfinder-core.md
@@ -60,7 +60,7 @@ Using [Dask arrays](https://docs.dask.org/en/latest/array.html) allows for lazy 
 
 ```python
 from cellfinder.core.main import main as cellfinder_run
-from cellfinder.core.tools.IO import read_with_dask
+from brainglobe_utils.IO.image.load import read_with_dask
 
 signal_array = read_with_dask("/path/to/signal_image_directory")
 background_array = read_with_dask("/path/to/background_image_directory")

--- a/docs/source/documentation/index.md
+++ b/docs/source/documentation/index.md
@@ -58,8 +58,7 @@ Once you have installed `brainglobe`, or [installed an individual tool](#install
 setting-up/index
 brainglobe-atlasapi/index
 brainglobe-space/index
-brainglobe-utils/citation-module
-brainglobe-utils/image_io
+brainglobe-utils/index
 brainreg/index
 brainglobe-segmentation/index
 brainglobe-workflows/index


### PR DESCRIPTION
This PR:
- Moves the image IO docs into the brainglobe-utils section (closes #160)
- Updates the docs to reflect moving data loading code out of cellfinder into brainglobe-utils (see https://github.com/brainglobe/brainglobe-utils/pull/73)
- briefly documents the `read_with_dask` function