### PR TITLE
Remove reference to slow running tests in the developer docs

### DIFF
--- a/docs/source/community/developers/testing.md
+++ b/docs/source/community/developers/testing.md
@@ -5,20 +5,6 @@ are tested, including both unit and integration tests. We aim for 100% coverage 
 * We use [codecov](https://about.codecov.io/) as the coverage reporting tool. This is free for open-source
   projects and integrates with GitHub actions.
 
-## Long running tests
-Some tests may take a long time, e.g. those requiring `TensorFlow` if you don't have a GPU. These tests should be
-marked with `@pytest.mark.slow`, e.g.:
-
-```python
-import pytest
-@pytest.mark.slow
-def test_something_slow() -> None:
-    slow_result = run_slow_processes()
-    assert slow_result == expected_slow_thing, "some useful error message"
-```
-
-During development, these "slow" tests can be skipped by running `pytest -m "not slow"`.
-
 ## Continuous integration
 A GitHub actions workflow (`.github/workflows/test_and_deploy.yml`) has been set up to run (on each commit/PR):
 * Linting checks (pre-commit).


### PR DESCRIPTION
Removes the references instructing developers how to mark slow running tests that won't be run by default. I think this is a bad idea, because it encourages devs to add tests that, in practice, will never be run. We should try to write tests that can run quickly in CI.

~AFAIK we only have one repo that has these slow running tests remaining (brainrender). This is [documented on the readme](https://github.com/brainglobe/brainrender?tab=readme-ov-file#contributing) and I think should be fixed anyway.~

EDIT: these slow running test markers have been removed in https://github.com/brainglobe/brainrender/pull/348