### PR TITLE
Use correct pip upgrade flag

### DIFF
--- a/docs/source/blog/atlasapi-atlasgen-merge.md
+++ b/docs/source/blog/atlasapi-atlasgen-merge.md
@@ -21,7 +21,7 @@ As such, it has now been moved into a submodule, `brainglobe_atlasapi.atlas_gene
 If you are using an install of `bg-atlasapi` that you got through `pip install brainglobe`, then all you need to do is update `brainglobe` to the latest version with
 
 ```bash
-pip install --update brainglobe
+pip install --upgrade brainglobe
 ```
 
 This will remove the old packages from your environment, install `brainglobe-atlasapi`, and also update all your other BrainGlobe tools to use the new package rather than the old `bg-atlasapi`.

--- a/docs/source/blog/bg-space-rename.md
+++ b/docs/source/blog/bg-space-rename.md
@@ -20,7 +20,7 @@ Beyond this name change, there will be no functionality changes to the package, 
 Users who installed BrainGlobe through it's single ("meta") package install with `pip install brainglobe` will just need to update the package by running
 
 ```bash
-pip install brainglobe --update
+pip install brainglobe --upgrade
 ```
 
 in your environment, which will fetch the new version of all the affected packages.

--- a/docs/source/blog/brainglobe-v1_1.md
+++ b/docs/source/blog/brainglobe-v1_1.md
@@ -23,18 +23,18 @@ release. In particular, he has made many contributions to `cellfinder`, includin
 If you have an installation of the metapackage (recommended) then all you need to do is update `brainglobe` to the 
 latest version with:
 ```bash
-pip install --update brainglobe
+pip install --upgrade brainglobe
 ```
 
 If you use `brainglobe-workflows` (e.g. for `brainmapper`) you will need to update it individually, as it is not 
 included within the metapackage:
 ```bash
-pip install --update brainglobe-workflows
+pip install --upgrade brainglobe-workflows
 ```
 
 If you have a single tool installed, you can just update that tool. For example to update `brainrender`, run:
 ```bash
-pip install --update brainrender
+pip install --upgrade brainrender
 ```
 
 ## Details

--- a/docs/source/blog/imio-retirement.md
+++ b/docs/source/blog/imio-retirement.md
@@ -28,7 +28,7 @@ In terms of your source code, the only necessary changes should be to:
 Users who installed BrainGlobe through it's single ("meta") package install with `pip install brainglobe` will just need to update the package by running
 
 ```bash
-pip install brainglobe --update
+pip install brainglobe --upgrade
 ```
 
 in your environment, which will fetch the new version of all the affected packages.
@@ -38,7 +38,7 @@ If you are manually managing your BrainGlobe tools, you will need to uninstall `
 
 ```bash
 pip uninstall imio
-pip install --update brainglobe-utils
+pip install --upgrade brainglobe-utils
 ```
 
 You'll also need to update the following packages, which now depend on at least `brainglobe-utils` version 0.4.0 instead of `imio`:

--- a/docs/source/community/developers/repositories/brainglobe-meta/index.md
+++ b/docs/source/community/developers/repositories/brainglobe-meta/index.md
@@ -23,7 +23,7 @@ or
 python -m pip install brainglobe
 ```
 
-Pass the `-U` or `--update` flag to `pip` to force an update on an existing install.
+Pass the `-U` or `--upgrade` flag to `pip` to force an update on an existing install.
 
 ## Conventions
 

--- a/docs/source/documentation/index.md
+++ b/docs/source/documentation/index.md
@@ -36,7 +36,7 @@ Otherwise, it will use the version of `brainglobe` that you already have install
 You can update your BrainGlobe tools by running
 
 ```bash
-pip install brainglobe --update
+pip install brainglobe --upgrade
 ```
 
 in your virtual environment.


### PR DESCRIPTION
Fixes (many) instances of `pip install --update` being used instead of `pip install --upgrade`. 

Thanks to @GuillaumeLeGoc for letting us know!