### PR TITLE
Ignore URLs that fail link check on CI

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -195,5 +195,6 @@ linkcheck_ignore = [
     "https://neuromorpho.org/",
     "https://brainglobe.zulipchat.com/#narrow/stream/414089-developer-meeting",
     "https://easyengine.io",
-    "https://www.scientifica.uk.com"
+    "https://www.scientifica.uk.com",
+    "https://brainglobe.info"
     ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -193,5 +193,7 @@ notfound_urls_prefix = None
 
 linkcheck_ignore = [
     "https://neuromorpho.org/",
-    "https://brainglobe.zulipchat.com/#narrow/stream/414089-developer-meeting"
+    "https://brainglobe.zulipchat.com/#narrow/stream/414089-developer-meeting",
+    "https://easyengine.io",
+    "https://www.scientifica.uk.com"
     ]


### PR DESCRIPTION
Not sure why this is needed (the links are fine locally), but otherwise the docs won't build...