### PR TITLE
Disable link check

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: neuroinformatics-unit/actions/build_sphinx_docs@main
+        with:
+          check-links: false
 
   deploy_sphinx_docs:
     name: Deploy Sphinx Docs


### PR DESCRIPTION
This is getting annoying, as it often prevents the docs from building. I assume it's due to something stopping bots, but 🤷. We can (should) still run this locally, and maybe renable it in the future. 