### PR TITLE
Fix barrel atlas blog date

### DIFF
--- a/docs/source/blog/barrel-atlas-added.md
+++ b/docs/source/blog/barrel-atlas-added.md
@@ -1,6 +1,6 @@
 ---
 blogpost: true
-date: July 22, 2024
+date: August 02, 2024
 author: Adam Tyson, Axel Bisi
 location: London, U.K.; Lausanne, Switzerland
 category: brainglobe


### PR DESCRIPTION
I forgot to push the changes updating the blog date. It seems like they should be in chronological order. 