### PR TITLE
Removed reference to "save weights" from training-the-network.md

### DIFF
--- a/docs/source/documentation/cellfinder/user-guide/napari-plugin/training-the-network.md
+++ b/docs/source/documentation/cellfinder/user-guide/napari-plugin/training-the-network.md
@@ -28,14 +28,12 @@ When training your network, you can either train the network from scratch (not r
 - If you are training a new network from scratch (i.e. **Continue training** is not selected), then you only need to select a **Model depth**.
 - If you are continuing training from a default, pretrained model, only **Pretrained model** needs to be chosen.
 - If you are continuing training from your own model, then only **Trained model** needs to be set.
-- If you are continuing training from your own model weights (i.e. not the full model, saved when **Save weights** is checked).
 
 #### Training
 
 - **Continue Training** - Continue training from an existing trained model. If no model or model weights are specified, this will continue from the included model.
 - **Augment** - Use data augmentation to synthetically increase the amount of training data
 - **Tensorboard** - Log to `output_directory/tensorboard`. Use `tensorboard --logdir outputdirectory/tensorboard` to view.
-- **Save weights** - Only store the model weights, and not the full model. Useful to save storage space.
 - **Save checkpoints** - Save the model after each training epoch. Each model file can be large, and if you don't have much training data, they can be generated quickly. Deselect if you are training for many epochs, and you are happy to wait for the chosen number of epochs to complete.
 - **Save progress** - Save training progress to a .csv file (`output_directory/training.csv`)
 - **Epochs** - How many times to use each sample for training. **Default: 100**


### PR DESCRIPTION
## Description
Removed reference to the save_weights option in the documentation page "training-the-network.md" following function removal from Napari training plugin in #499

**What is this PR**
Addresses enhancement #315

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
To make documentation clear and align with the Napari training plugin

**What does this PR do?**
Updates documentation "training-the-network.md" 

## How has this PR been tested?
Have previewed through GitHub to visually confirm changes

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No, this is a docs update

## Checklist:

- [X] The code has been tested locally
- [X] The documentation has been updated to reflect any changes
