### PR TITLE
add Kaixiang and Giulia as contributors

### DIFF
--- a/docs/source/people.md
+++ b/docs/source/people.md
@@ -633,6 +633,17 @@ In no particular order:
 :link: https://github.com/TimMonko
 :::
 
+:::{grid-item-card}    Kaixiang Shuai
+:img-bottom: https://avatars.githubusercontent.com/u/108368488?v=4
+:link: https://github.com/Skxsmy
+:::
+
+:::{grid-item-card}    Giulia Paci
+:img-bottom: https://avatars.githubusercontent.com/u/33309117?v=4
+:link: https://github.com/giuliapaci
+:::
+
+
 ::::
 
 Inspired by [All Contributors](https://allcontributors.org/). All information is sourced from GitHub. If any changes 


### PR DESCRIPTION
I merged https://github.com/brainglobe/brainglobe-template-builder/pull/66 by @Skxsmy (co-supervised by @giuliapaci), because it has successfully been used to generate a new template.
