### PR TITLE
docs(brainglobe-space): standardize import alias in examples

### DIFF
--- a/docs/source/documentation/brainglobe-space/index.md
+++ b/docs/source/documentation/brainglobe-space/index.md
@@ -28,11 +28,11 @@ target_origin = ("Inferior", "Posterior", "Right")
 A stack can be then easily transformed from the source to the target space:
 
 ```python
-import brainglobe_space as bg
+import brainglobe_space as bgs
 import numpy as np
 stack = np.random.rand(3, 2, 4)
 
-mapped_stack = bg.map_stack_to(source_origin, target_origin, stack)
+mapped_stack = bgs.map_stack_to(source_origin, target_origin, stack)
 ```
 
 The transformation is handled only with numpy index operations; i.e., no complex image affine transformations are 
@@ -41,7 +41,7 @@ applied. This is often useful as the preparatory step for starting any kind of i
 A shortened syntax can be used to define a space using initials of the origin directions:
 
 ```python
-mapped_stack = bg.map_stack_to("lsa", "ipr", stack)
+mapped_stack = bgs.map_stack_to("lsa", "ipr", stack)
 ```
 
 :::{note}  When you work with a stack, the origin is the upper left corner when you show the first element 
@@ -61,7 +61,7 @@ To handle this situation, we can define a source space using the `AnatomicalSpac
 stack = np.random.rand(3, 2, 4)  # a stack in source space
 annotations = np.array([[0, 0, 0], [2, 1, 3]])  # related point annotations
 
-source_space = bg.AnatomicalSpace(source_origin, stack.shape)
+source_space = bgs.AnatomicalSpace(source_origin, stack.shape)
 
 mapped_stack = source_space.map_stack_to("ipr", stack)  # transform the stack
 mapped_annotations = source_space.map_points_to("ipr", annotations)  # transform the points
@@ -71,13 +71,13 @@ The points are transformed through the generation of a transformation matrix. Fi
 matrix (e.g., to reconstruct the full transformations sequence of a registration), we can get it:
 
 ```python
-target_space = bg.AnatomicalSpace("ipr", stack.shape)
+target_space = bgs.AnatomicalSpace("ipr", stack.shape)
 transformation_matrix = source_space.transformation_matrix_to(target_space)
 # equivalent to:
 transformation_matrix = source_space.transformation_matrix_to("ipr", stack.shape)
 ```
 
-The target get always be defined as a `bg.AnatomicalSpace` object, or a valid origin specification plus a shape 
+The target get always be defined as a `bgs.AnatomicalSpace` object, or a valid origin specification plus a shape 
 (the shape is required only if axes flips are required).
 
 ### Matching space resolutions and offsets
@@ -108,7 +108,7 @@ Finally, another convenient feature of brainglobe-space is the possibility of it
 the stack and generate section names and axes labels:
 
 ```python
-sc = bg.AnatomicalSpace("asl")  # origin for the stack to be plotted
+sc = bgs.AnatomicalSpace("asl")  # origin for the stack to be plotted
 
 for i, (plane, labels) in enumerate(zip(sc.sections, sc.axis_labels)):
     axs[i].imshow(stack.mean(i))


### PR DESCRIPTION
closes #344

- Update the import alias for brainglobe_space from bg to bgs in all Python code examples.
- Standardize the alias used for the brainglobe_space library across the documentation.

