### PR TITLE
Install dev dependencies when parsing docstrings

### DIFF
--- a/docs/fetch_repos.py
+++ b/docs/fetch_repos.py
@@ -13,15 +13,16 @@ print("Starting to fetch repositories...")
 
 # This list explicitly includes repositories whose docstrings have been vetted
 # for public consumption in the API documentation.
-# Format: (repository_url, local_download_path, branch)
+# Format: (repository_url, local_download_path, branch, optional_dependencies)
+# Use empty string for no optional dependencies.
 REPOS = [
-    ("https://github.com/brainglobe/brainglobe-atlasapi.git", "downloads/brainglobe-atlasapi", "main"),
-    # Add more (url, path, branch) pairs as needed
+    ("https://github.com/brainglobe/brainglobe-atlasapi.git", "downloads/brainglobe-atlasapi", "main", "[atlasgen]"),
+    # Add more (url, path, branch, optional) pairs as needed
 ]
 
 print(f"Found {len(REPOS)} repositories to process.")
 
-for url, path, branch in REPOS:
+for url, path, branch, optional_deps in REPOS:
     print(f"Processing repository: {url} -> {path} (branch: {branch})")
     # If the repository does not exist locally, clone it
     if not os.path.exists(path):
@@ -38,7 +39,7 @@ for url, path, branch in REPOS:
 
     # Install the repository in editable mode
     print(f"Installing {path} in editable mode...")
-    subprocess.run(["pip", "install", "-e", f"{path}[dev]"], check=True)
+    subprocess.run(["pip", "install", "-e", f"{path}{optional_deps}"], check=True)
     print(f"Successfully installed {path}.")
 
 print("All repositories fetched and installed successfully.")


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
In order to successfully build and parse docstrings all dependencies must be installed. Currently, only the core dependencies are installed, therefore any docstrings that rely on optional dependencies throw an error and are excluded from the website API docs.

**What does this PR do?**
Installs the optional `dev` dependencies when setting up the environment for parsing docstrings. If the optional dependencies are part of dev (see https://github.com/brainglobe/brainglobe-atlasapi/pull/639) then they're installed to the enivronment.

## How has this PR been tested?
Tested locally.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
