### PR TITLE
Add napari handedness info for brainrender compatibility

### DIFF
--- a/docs/source/documentation/setting-up/image-definition.md
+++ b/docs/source/documentation/setting-up/image-definition.md
@@ -41,13 +41,13 @@ microns, then the voxel sizes would be `5 2 2`.
 
 ## Napari 3D Orientation for brainrender
 
-napari v0.6.0 and later use a **right-handed 3D coordinate system** by default, however brainrender expects a **left-handed system**, so 3D visualisations may appear mirrored (left-right flipped).  
+`napari v0.6.0` and later use a **right-handed 3D coordinate system** by default, however `brainrender` expects a **left-handed system**, so 3D visualisations may appear mirrored (left-right flipped).  
 
-To fix this:
+To change to a left-handed system
 
 1. Right-click the **Toggle 2D/3D view** button in the bottom-left corner.  
 2. Select the pre-0.6.0 default: **away, down, right**.  
 
-This ensures correct visualisation in brainrender.  
+This ensures `napari`'s visualisation matches `brainrender`'s.  
 For more details on napari’s 3D axis directions and handedness, see the [napari documentation](https://napari.org/stable/guides/handedness.html).
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

This PR adds a short explanatory note to the “Orientation” section of the Setting Up documentation to clarify how napari’s default axis orientation and handedness changed in version 0.6.0 and how this can affect brainrender visualisation. It helps users understand why their data may appear mirrored and how to correct it.

**What does this PR do?**

- Adds a subsection titled "Napari 3D Orientation for brainrender" to the Setting Up docs
- Explains that napari ≥0.6.0 uses a right-handed coordinate system by default, while brainrender expects a left-handed one.
- Provides instructions on how to restore the pre-0.6.0 orientation 
- Includes a link to the official napari documentation for further details.

## References

Closes #383 

## How has this PR been tested?
This is a documentation-only change 

## Is this a breaking change?
If this PR breaks any existing functionality, please explain how and why.

No 

## Does this PR require an update to the documentation?
If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
