### PR TITLE
Explicitly use conda-forge as the source channel in instructions

### DIFF
--- a/docs/source/documentation/brainrender/installation.md
+++ b/docs/source/documentation/brainrender/installation.md
@@ -10,11 +10,20 @@ pip install brainrender
 ```
 
 :::{caution}
-With newer versions of Python on Windows, you may need to run `conda install pyside2` before running `pip install`.
+With newer versions of Python on Windows, you may need to run:
+```bash
+conda install -c conda-forge ffmpeg
+conda install -c conda-forge pyside2
+```
+before running `pip install brainrender`.
 :::
 
 :::{caution}
-On Silicon Macs, you may need to run `conda install hdf5` before running `pip install`.
+On Silicon Macs, you may need to run:
+```bash
+conda install -c conda-forge hdf5
+```
+before running `pip install`.
 :::
 
 :::{caution}

--- a/docs/source/documentation/index.md
+++ b/docs/source/documentation/index.md
@@ -6,7 +6,7 @@ We always recommend that you install BrainGlobe tools into a virtual environment
 Your environment should run Python 3.10, 3.11 or 3.12. To specify the Python version for new conda environment, add it as a parameter on creation:
 
 ```bash
-conda create -n brainglobe-env python=3.12
+conda create -c conda-forge -n brainglobe-env python=3.12
 ```
 
 Once you have created and activated your desired environment, you can install all BrainGlobe tools using `pip`:

--- a/docs/source/documentation/setting-up/conda.md
+++ b/docs/source/documentation/setting-up/conda.md
@@ -66,7 +66,7 @@ The `(base)` is the bit that tells you that conda is set up
 Open a terminal (or Anaconda Prompt) and type:
 
 ```bash
-conda create --name ENV_NAME python=3.12
+conda create -c conda-forge --name ENV_NAME python=3.12
 ```
 
 This will:


### PR DESCRIPTION
Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
See https://github.com/brainglobe/brainrender/issues/429

**What does this PR do?**
Add `-c conda-forge` to conda instructions to ensure conda-forge is used as the package source.

## References
https://github.com/brainglobe/brainrender/issues/429

## How has this PR been tested?
Visual inspection from a local build.

## Is this a breaking change?
No

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
