### PR TITLE
Add Fatma S. Elsharkawy to people.md

### DIFF
--- a/docs/source/people.md
+++ b/docs/source/people.md
@@ -661,6 +661,7 @@ In no particular order:
 :img-bottom: https://avatars.githubusercontent.com/u/125503056?v=4
 :link: https://github.com/FatmaElsharkawy
 :::
+
 ::::
 
 Inspired by [All Contributors](https://allcontributors.org/). All information is sourced from GitHub. If any changes 


### PR DESCRIPTION
## Description

Adds @FatmaElSharkawy to contributors, following her contribution to cellfinder's napari UX in https://github.com/brainglobe/cellfinder/pull/510