### PR TITLE
docs: add Nishanth B to people.md

### DIFF
--- a/docs/source/people.md
+++ b/docs/source/people.md
@@ -692,12 +692,15 @@ In no particular order:
 :link: https://orcid.org/0000-0003-1637-2522
 :::
 
-
 :::{grid-item-card} Leoni-Marie Webb
 :img-bottom: 
 :link: 
 :::
 
+:::{grid-item-card} Nishanth B
+:img-bottom: https://avatars.githubusercontent.com/u/150372232?v=4
+:link: https://github.com/nishanthcr7777
+:::
 ::::
 
 Inspired by [All Contributors](https://allcontributors.org/). All information is sourced from GitHub. If any changes 


### PR DESCRIPTION
This PR adds myself (Nishanth B) to the BrainGlobe contributors list following recent merged contributions to brainglobe-atlasapi.

Added a new grid card entry to `people.md` including full name, GitHub avatar, and GitHub profile link.
No existing contributor entries were modified beyond removal of one extra blank line.
