### PR TITLE
#Fix #358: Add missing registered hemisphere layer to visualization guide

### DIFF
--- a/docs/source/documentation/brainreg/user-guide/visualisation.md
+++ b/docs/source/documentation/brainreg/user-guide/visualisation.md
@@ -10,7 +10,7 @@ Various images should then open, including:
 * `Registered image` - the image used for registration, downsampled to atlas resolution
 * `atlas_name` - e.g. `allen_mouse_25um` the atlas labels, warped to your sample brain
 * `Boundaries` - the boundaries of the atlas regions
-* `Registered hemisphere` - the hemisphere annotations , warped to your sample brain
+* `Hemispheres` - the hemisphere annotations, warped to your sample brain
 If you downsampled additional channels, these will also be loaded.
 
 Some of these images will not be visible by default. Click the little eye icon to toggle visibility.


### PR DESCRIPTION
#Fixes 358

This PR updates the brainreg visualization documentation to include the missing "Registered hemisphere" layer that is loaded by default when opening brainreg output in napari.

##Changes:
-Added `Registered hemisphere` to the list of default layers in the visualization guide

##Notes:
-The demonstration GIF should also be updated to show this layer (I don't currently have the setup to create this)
-Please verify if the hemisphere layer loads under all conditions or only with specific configuration flags

## Checklist:
-[x]  Documentation text updated 
-[ ] GIF updated (requires maintainer assistance)
-[ ] Conditional loading verified (requires maintainer review)