### PR TITLE
Remove contact page from index toctree

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -59,4 +59,3 @@ community/index
 blog/index
 projects/index
 blackcap
-contact


### PR DESCRIPTION
We don't need the contact page to be in the top navbar as it has it's own card now. This also fixes the issue of the contact page not having a "section navigation" bar on the left (thanks to @IgorTatarnikov).