### PR TITLE
Remove [atlasgen] extras to fix Python 3.14 build failure

### DIFF
--- a/docs/fetch_repos.py
+++ b/docs/fetch_repos.py
@@ -16,7 +16,7 @@ print("Starting to fetch repositories...")
 # Format: (repository_url, local_download_path, branch, optional_dependencies)
 # Use empty string for no optional dependencies.
 REPOS = [
-    ("https://github.com/brainglobe/brainglobe-atlasapi.git", "downloads/brainglobe-atlasapi", "main", "[atlasgen]"),
+    ("https://github.com/brainglobe/brainglobe-atlasapi.git", "downloads/brainglobe-atlasapi", "main", ""),
     # Add more (url, path, branch, optional) pairs as needed
 ]
 


### PR DESCRIPTION
## Description
**What is this PR**
- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Building the docs with Python 3.14 fails because installing `brainglobe-atlasapi[atlasgen]` pulls in `rapidyaml` as a transitive dependency. `rapidyaml` has no Python 3.14 wheel, so the build crashes at the wheel compilation step.

**What does this PR do?**
Removes the `[atlasgen]` extras from the `brainglobe-atlasapi` install in `fetch_repos.py`. The docs build only needs the base package to read docstrings — atlas generation modules are already explicitly excluded in `make_api_index.py`.

## References
Fixes #438

## How has this PR been tested?
Verified locally that `fetch_repos.py` now installs `brainglobe-atlasapi` without extras, avoiding the `rapidyaml` wheel build entirely. The CI pipeline runs on Python 3.12 where this was not reproducible, but the fix removes the problematic dependency regardless of Python version.

## Is this a breaking change?
No. The `[atlasgen]` extras were never needed for the docs build.

## Does this PR require an update to the documentation?
No.

## Checklist:
- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)