### PR TITLE
Generate API docs when linkcheck is run

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: 3.12
           use-make: true
-          check-links: false
+          check-links: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy_sphinx_docs:

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           python-version: 3.12
           use-make: true
-          check-links: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy_sphinx_docs:

--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           python-version: 3.12
           use-make: true
+          check-links: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy_sphinx_docs:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -61,6 +61,10 @@ generate_api_toctrees:
 html: fetch_repos make_api_index generate_api_toctrees
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+# Run linkcheck after generating the same API docs that html depends on.
+linkcheck: fetch_repos make_api_index generate_api_toctrees
+	@$(SPHINXBUILD) -M linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,7 @@ exclude_patterns = [
     "**_examples_source",
 ]
 
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -212,7 +212,7 @@ linkcheck_ignore = [
     "https://www.world-wide.org/seminar/6583/",
     "https://doi.org", # Various errors due to rate-limiting and time outs
     "https://elifesciences.org", # 406 Client Error: Not Acceptable
-    "https://biorxiv.org", # 403 Client Error: Forbidden
+    "https://www.biorxiv.org", # 403 Client Error: Forbidden
     ]
 
 linkcheck_anchors_ignore_for_url = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -212,6 +212,7 @@ linkcheck_ignore = [
     "https://www.world-wide.org/seminar/6583/",
     "https://doi.org", # Various errors due to rate-limiting and time outs
     "https://elifesciences.org", # 406 Client Error: Not Acceptable
+    "https://biorxiv.org", # 403 Client Error: Forbidden
     ]
 
 linkcheck_anchors_ignore_for_url = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,6 +95,8 @@ exclude_patterns = [
 ]
 
 
+autosummary_generate = True
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,8 +94,6 @@ exclude_patterns = [
     "**_examples_source",
 ]
 
-autosummary_generate = True
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,8 @@ exclude_patterns = [
     "**_examples_source",
 ]
 
+autosummary_generate = True
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,9 +94,6 @@ exclude_patterns = [
     "**_examples_source",
 ]
 
-
-autosummary_generate = True
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
API docs were not generated when linkcheck was used due to caching of the toctree between the linkcheck run and the html make runs.

**What does this PR do?**
Runs the API doc generation on both linkcheck and html to ensure the toctree is correct.

## References
Closes #477 


## How has this PR been tested?
The artifact generated on CI was downloaded and inspected to ensure the correct pages are generated, and the links are embedded.

## Checklist:

- [x] The code has been tested locally
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
