### PR TITLE
Add GIN to linkcheck ignore list

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -217,7 +217,7 @@ linkcheck_ignore = [
     "https://elifesciences.org", # 406 Client Error: Not Acceptable
     "https://www.biorxiv.org", # 403 Client Error: Forbidden
     "https://mousespinal.brain-map.org",
-    "https://gin.g-node.org/BrainGlobe", # often down, or throttling many requests
+    "https://gin.g-node.org", # often down, or throttling many requests
     ]
 
 linkcheck_anchors_ignore_for_url = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -217,7 +217,7 @@ linkcheck_ignore = [
     "https://elifesciences.org", # 406 Client Error: Not Acceptable
     "https://www.biorxiv.org", # 403 Client Error: Forbidden
     "https://mousespinal.brain-map.org",
-    "https://gin.g-node.org/BrainGlobe/atlases", # often down, or throttling many requests
+    "https://gin.g-node.org/BrainGlobe", # often down, or throttling many requests
     ]
 
 linkcheck_anchors_ignore_for_url = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -217,6 +217,7 @@ linkcheck_ignore = [
     "https://elifesciences.org", # 406 Client Error: Not Acceptable
     "https://www.biorxiv.org", # 403 Client Error: Forbidden
     "https://mousespinal.brain-map.org",
+    "https://gin.g-node.org/BrainGlobe/atlases", # often down, or throttling many requests
     ]
 
 linkcheck_anchors_ignore_for_url = [


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

GIN being down seems to be the root cause of build errors, including on `main`, and leading to a mismatch between the code on `main` and brainglobe.info.

We will still be notified of GIN being down via our scheduled (e.g. Atlas API) tests.

**What does this PR do?**

Adds GIN's URL to ignore-list for link checker.

## References

Closes #494 

## How has this PR been tested?

Keeping this PR in draft until CI passes.
I will continue to check in on the build and triple-check but hard to test locally.

## Is this a breaking change?

Nope.

## Does this PR require an update to the documentation?

Is one.
