### PR TITLE
Replace custom author byline with ABlog postcard sidebar

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -64,20 +64,3 @@ body .bd-article-container {
   margin-bottom: 0 !important;
 }
 
-.blog-post-author {
-  border-left: 3px solid var(--pst-color-primary);
-  color: var(--pst-color-text-muted);
-  font-size: 1.12rem;
-  line-height: 1.5;
-  margin-top: -0.2rem;
-  margin-bottom: 2rem;
-  padding-left: 0.8rem;
-}
-
-.blog-post-author a {
-  font-weight: 600;
-}
-
-.blog-post-author .line:nth-child(2) {
-  font-size: 1rem;
-}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,11 +14,6 @@ import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-from ablog.blog import Blog
-from docutils import nodes
-from sphinx.errors import ExtensionError
-
-
 # -- Project information -----------------------------------------------------
 
 project = "BrainGlobe"
@@ -180,6 +175,23 @@ html_theme_options = {
     "external_links": [],
 }
 
+# Show ABlog's "postcard" (date, author, category, etc.) in the sidebar of blog
+# post pages, see https://ablog.readthedocs.io/en/latest/manual/templates-themes.html
+# Note: this replaces the default site nav sidebar on blog pages only.
+html_sidebars = {
+    "blog/index": [
+        "ablog/authors.html",
+        "ablog/archives.html",
+    ],
+    "blog/**": [
+        "ablog/postcard.html",
+        "ablog/recentposts.html",
+    ],
+}
+
+# The PyData theme bundles FontAwesome, so let ABlog render its postcard icons
+# (calendar, user, ...) instead of plain-text "Author:"/"Location:" labels.
+fontawesome_included = True
 
 html_show_sourcelink = False
 
@@ -230,54 +242,3 @@ linkcheck_request_headers = {
     },
 }
 
-
-def add_blog_author_byline(app, doctree, docname):
-    """Add ABlog author metadata to individual blog post pages."""
-    posts = getattr(app.env, "ablog_posts", {}).get(docname, [])
-    if len(posts) != 1:
-        return
-
-    post = posts[0]
-    authors = post.get("author", [])
-    date = post.get("date")
-    if not authors or not date:
-        raise ExtensionError(
-            f"Blog post '{docname}' must define both author and date metadata."
-        )
-
-    byline = nodes.line_block(classes=["blog-post-author"])
-
-    if authors:
-        author_line = nodes.line()
-        author_line += nodes.Text("By ")
-
-        blog = Blog(app)
-        author_catalog = blog.catalogs["author"].collections
-        for index, author in enumerate(authors):
-            if index:
-                author_line += nodes.Text(", ")
-
-            author_page = author_catalog.get(author)
-            if author_page is None:
-                author_line += nodes.Text(author)
-                continue
-
-            author_line += nodes.reference(
-                "",
-                author,
-                refuri=app.builder.get_relative_uri(docname, author_page.docname),
-            )
-
-        byline += author_line
-
-    if date:
-        byline += nodes.line(text=date.strftime(app.config["post_date_format"]))
-
-    for section in doctree.findall(nodes.section):
-        if section.children and isinstance(section.children[0], nodes.title):
-            section.insert(1, byline)
-            return
-
-
-def setup(app):
-    app.connect("doctree-resolved", add_blog_author_byline)


### PR DESCRIPTION
Reverts the custom author byline introduced in #496 and replaces it with ABlog's built-in postcard sidebar templates, following the same approach used in neuroinformatics-unit/movement#990. See discussion under the `movement` PR for context on how we reached this decision.


Preview.

<img width="1468" height="653" alt="image" src="https://github.com/user-attachments/assets/5e366f44-de35-47e4-a5fa-f8edddc1dbbf" />

## Changes

- Remove the `add_blog_author_byline` Sphinx extension hook and its imports from `conf.py`
- Remove the `.blog-post-author` CSS block from `custom.css`
- Add `html_sidebars` config to use ABlog's native `postcard.html` + `recentposts.html` templates on blog post pages, and `authors.html` + `archives.html` on the blog index
- Set `fontawesome_included = True` so ABlog renders icons via the FontAwesome already bundled by the PyData theme