### PR TITLE
Add robots.txt for sitemap discovery

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,7 +96,9 @@ exclude_patterns = [
 
 # -- Options for HTML output -------------------------------------------------
 
+# Include robots.txt in the built site.
 html_extra_path = ["robots.txt"]
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,6 +96,7 @@ exclude_patterns = [
 
 # -- Options for HTML output -------------------------------------------------
 
+html_extra_path = ["robots.txt"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+
+Sitemap: https://brainglobe.info/sitemap.xml


### PR DESCRIPTION
## Description

**What is this PR**

* [ ] Bug fix
* [ ] Addition of a new feature
* [x] Other

**Why is this PR needed?**

This PR helps crawlers discover the BrainGlobe website sitemap by adding a `robots.txt` file that points to the generated sitemap.

**What does this PR do?**

This PR adds `docs/source/robots.txt` with a sitemap reference and registers it in `html_extra_path` in `docs/source/conf.py` so Sphinx copies it into the built site.

## References

Closes #505

## How has this PR been tested?

Built the documentation locally and confirmed that `robots.txt` is copied into the built HTML output.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No. This only adds a site metadata file for crawlers and does not change user-facing documentation.

## Checklist:

* [ ] The code has been tested locally
* [ ] Tests have been added to cover all new functionality (unit & integration)
* [ ] The documentation has been updated to reflect any changes
* [ ] The code has been formatted with [[pre-commit](https://pre-commit.com/)](https://pre-commit.com/)