### PR TITLE
Unify the html_extra_path variables

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,9 +96,6 @@ exclude_patterns = [
 
 # -- Options for HTML output -------------------------------------------------
 
-# Include robots.txt in the built site.
-html_extra_path = ["robots.txt"]
-
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
@@ -115,7 +112,7 @@ sitemap_url_scheme = "{link}"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-html_extra_path = ["_redirects"]
+html_extra_path = ["_redirects", "robots.txt"]
 
 html_css_files = [
     ("css/custom.css", {"priority": 100}),


### PR DESCRIPTION
The `robots.txt` file introduced in #513 wasn't being copied during the build as `html_extra_path` was defined twice.

This unifies the two variables into one list.