### PR TITLE
Fix linkcheck failures on S3 and swcmicroscopy

### DIFF
--- a/docs/source/aws_examples_source/explore_atlas.py
+++ b/docs/source/aws_examples_source/explore_atlas.py
@@ -42,8 +42,8 @@ from matplotlib import colormaps as cm
 # Next, we use pandas to access the terminologies files using its S3 URI.
 
 s3_bucket_stub = "s3://brainglobe/atlas/{}"
-annotation_uri = s3_bucket_stub.format("annotation-sets/allen_mouse-annotation/1_2/annotation.ome.zarr")
-terminologies_uri = s3_bucket_stub.format("terminologies/allen_mouse-terminology/1_2/terminology.csv")
+annotation_uri = s3_bucket_stub.format("annotation-sets/allen_mouse-annotation/3_0/annotations.ome.zarr")
+terminologies_uri = s3_bucket_stub.format("terminologies/allen_mouse-terminology/3_0/terminology.csv")
 
 terminologies_df = pd.read_csv(terminologies_uri, storage_options={"anon": True})
 

--- a/docs/source/aws_examples_source/explore_atlas.py
+++ b/docs/source/aws_examples_source/explore_atlas.py
@@ -42,7 +42,7 @@ from matplotlib import colormaps as cm
 # Next, we use pandas to access the terminologies files using its S3 URI.
 
 s3_bucket_stub = "s3://brainglobe/atlas/{}"
-annotation_uri = s3_bucket_stub.format("annotation-sets/allen_mouse-annotation/3_0/annotations.ome.zarr")
+annotation_uri = s3_bucket_stub.format("annotation-sets/allen_mouse-annotation/3_0/annotations_compressed.ome.zarr")
 terminologies_uri = s3_bucket_stub.format("terminologies/allen_mouse-terminology/3_0/terminology.csv")
 
 terminologies_df = pd.read_csv(terminologies_uri, storage_options={"anon": True})

--- a/docs/source/tutorials/silicon-probe-tracking.md
+++ b/docs/source/tutorials/silicon-probe-tracking.md
@@ -39,7 +39,7 @@ order to avoid tissue damage.
 :::
 
 The brain is then thoroughly washed with 100mM PBS and imaged (e.g. by 
-[Serial 2-Photon Tomography](https://swcmicroscopy.com/ss_acquisition/); **Fig. 1**, 
+[Serial 2-Photon Tomography](https://swcmicroscopy.com/brainsaw/); **Fig. 1**, 
 right). We imaged 2 channels (one where DiI signal is detected and one with background fluorescence only) at a 
 resolution of x = 5μm, y = 5μm, z = 20μm.
 

--- a/docs/source/tutorials/tracing-tracking.md
+++ b/docs/source/tutorials/tracing-tracking.md
@@ -37,7 +37,7 @@ order to avoid tissue damage.
 :::
 
 The brain is then thoroughly washed with 100mM PBS and imaged (e.g. by 
-[Serial Section 2-Photon Tomography](https://swcmicroscopy.com/ss_acquisition)). Image channels 
+[Serial Section 2-Photon Tomography](https://swcmicroscopy.com/brainsaw)). Image channels 
 as needed according to number of tracing compounds (and extra channel is acquired as the background fluorescence only).
 
 


### PR DESCRIPTION
Following https://github.com/brainglobe/brainglobe-atlasapi/issues/885 the atlas example broke, this fixes the link.

Updated the links from https://swcmicroscopy.com/ss_acquisition to https://swcmicroscopy.com/brainsaw as there was a recent reorganisation 