### PR TITLE
Corrects `brainglobe-atlasapi` V3 blog 

### DIFF
--- a/docs/source/blog/brainglobe-atlasapi-v3-release.md
+++ b/docs/source/blog/brainglobe-atlasapi-v3-release.md
@@ -1,6 +1,6 @@
 ---
 blogpost: true
-date: Aug 7, 2026
+date: Aug 10, 2026
 author: Igor Tatarnikov
 location: London, England
 category: brainglobe


### PR DESCRIPTION
Fixes the blog date from Aug 7th to Aug 10th.